### PR TITLE
Add vale workflow

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,0 +1,65 @@
+name: Vale Review
+on:
+  workflow_call:
+    inputs:
+      repo:
+        description: "The repository to check, in the format owner/repo"
+        required: true
+        type: string
+      pr_number:
+        description: "The pull request number to check"
+        required: true
+        type: string
+    secrets:
+      GH_TOKEN:
+        required: true
+
+jobs:
+  review-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    outputs:
+      files: ${{ steps.get-modified-files.outputs.files }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: polkadot-developers/polkadot-docs
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: papermoonio/polkadot-mkdocs
+          sparse-checkout: |
+            .github/styles
+            .vale.ini
+          sparse-checkout-cone-mode: false
+          path: vale
+
+      - name: Move Vale files
+        run: |
+          mv vale/.vale.ini .
+          mv vale/.github/styles .github/styles
+
+      - name: Get modified files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        id: get-modified-files
+        run: |
+          changed_files=$(gh pr diff --repo ${{ inputs.repo }} --name-only ${{ inputs.pr_number }} | grep '\.md$' || true)
+          md_files=$(echo "$changed_files" | jq -R -s 'split("\n")[:-1]' | jq -c .)
+          echo "Modified md files: $md_files"
+          echo "files=$md_files" >> $GITHUB_OUTPUT
+
+      - name: Review docs
+        if: ${{ steps.get-modified-files.outputs.files != '[""]' }}
+        uses: errata-ai/vale-action@reviewdog
+        with:
+          files: ${{ steps.get-modified-files.outputs.files }}
+          vale_flags: "--no-exit"
+          reporter: github-pr-review
+          fail_on_error: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GH_TOKEN}}
+          REVIEWDOG_GITHUB_API_TOKEN: ${{secrets.GH_TOKEN}}


### PR DESCRIPTION
This PR adds a reusable GitHub Action workflow that automates Vale document reviews for the polkadot-docs repository. The workflow utilizes Vale configuration files and custom rules defined within this repository, enabling consistent style checking across documentation. 