### PR TITLE
pdot vocab vs ignore reorg

### DIFF
--- a/.github/styles/Papermoon/Acronyms.yml
+++ b/.github/styles/Papermoon/Acronyms.yml
@@ -15,6 +15,7 @@ exceptions:
   - CSS
   - CSV
   - DEBUG
+  - DNS
   - DOM
   - DPI
   - EVM
@@ -46,6 +47,7 @@ exceptions:
   - REPL
   - RPC
   - RSA
+  - SCALE
   - SCM
   - SCSS
   - SDK
@@ -61,6 +63,7 @@ exceptions:
   - URL
   - USB
   - UTF
+  - WSS
   - XCM
   - XML
   - XSS

--- a/.github/styles/Papermoon/CustomDictionary.yml
+++ b/.github/styles/Papermoon/CustomDictionary.yml
@@ -8,4 +8,7 @@ ignore:
   # Reference file location relative to styles/config/ignore directory
     # custom dictionary of cyrpto brands and token names/symbols
   - brand-token-ignore.txt
+    # case insensitive list of polkadot related words
+  - polkadot-ignore.txt
+  
     

--- a/.github/styles/Papermoon/NotContractions.yml
+++ b/.github/styles/Papermoon/NotContractions.yml
@@ -1,5 +1,5 @@
 extends: substitution
-message: "Use '%s' instead of '%s'."
+message: "Use '%s' instead of '%s' to improve clarity for the reader"
 link: 'https://developers.google.com/style/contractions'
 level: suggestion
 ignorecase: true

--- a/.github/styles/Papermoon/WordSwapList.yml
+++ b/.github/styles/Papermoon/WordSwapList.yml
@@ -19,16 +19,21 @@ swap:
   a\.k\.a|aka: or|also known as
   approx\.: approximately
   check box: checkbox
+  config: configuration
   disabled?: turn off|off|deactivate
   file name: filename
   HTTPs: HTTPS
   in order to: to
+  Nginx: nginx|NGINX
   open-source: open source
   "(?:Polkadot JS|Polkadot.Js|Polkadot.JS)": Polkadot.js
+  "(?:repo|repos)": repository|repositories
+  rpc: RPC
   stylesheet: style sheet
   tablename: table name
   url: URL
   vs\.: versus
+  whitelist: allowlist 
   wasm: Wasm
   
   

--- a/.github/styles/config/Papermoon.yml
+++ b/.github/styles/config/Papermoon.yml
@@ -1,9 +1,9 @@
-name: Papermoon
-description: "Custom style guide for enforcing Papermoon standards."
+name: PaperMoon
+description: "Custom style guide for enforcing PaperMoon standards."
 version: 0.1.0
 rules:
 
-  ### ALERT Level = Error (commit will fail) ###
+  ### ALERT Level = Error ###
 
   # Extends Vale dictionary to reference ignore files for customization
   CustomDictionary: error
@@ -13,13 +13,13 @@ rules:
   Titlecase.yml: error
 
 
-  ### ALERT Level = Warning (commit will succeed) ###
+  ### ALERT Level = Warning ###
 
   # Enforces custom version of Google.WordList
   WordSwapList.yml: warning
 
 
-  ### ALERT Level = Suggestion (commit will succeed) ###
+  ### ALERT Level = Suggestion ###
 
   # Prompts user to spell out unfamiliar acronyms first time they are used
   # Includes exception list to specify acronyms this rule will ignore

--- a/.github/styles/config/ignore/brand-token-ignore.txt
+++ b/.github/styles/config/ignore/brand-token-ignore.txt
@@ -7,6 +7,7 @@ Astar
 Celo
 CELO
 Ethereum
+ETH
 Grafana
 Klaytn
 Kujira
@@ -15,6 +16,8 @@ Moonbeam
 Moonriver
 Moonbase Alpha
 Polkadot
+Rococo
+ROC
 Sei
 Solana
 Uniswap

--- a/.github/styles/config/ignore/polkadot-ignore.txt
+++ b/.github/styles/config/ignore/polkadot-ignore.txt
@@ -1,0 +1,26 @@
+args
+backchannel
+blockHash
+bootnode
+bootnodes
+composable
+coretime
+dispatchable
+extrinsics
+forkless
+inherents
+invulnerables
+liveness
+multilocation
+omninode
+parachain
+parachain's
+parachains
+parathread
+relay chain
+relay chains
+runtimes
+Smoldot
+solochain
+subxt
+sudo

--- a/.github/styles/config/vocabularies/Industry/accept.txt
+++ b/.github/styles/config/vocabularies/Industry/accept.txt
@@ -14,24 +14,29 @@ Etherscan
 EVM 
 EVMs
 Ethereum
+hardcoded
 href
 Injective
 JavaScript
 JSON-RPC
-keystore
-keystores
+[Kk]eystore
+[Kk]eystores
 Merkle
 mintable
 multisig
 namespace
 namespaces
+nginx
 npm
 npx
 onboarded
 onboarding
 picosecond
 Podman
+Prometheus
 Protobuf
+proxied
+proxying
 SDK
 snake_case
 subcommand
@@ -41,9 +46,12 @@ tooltip
 [Tt]rie
 TypeScript
 [Vv]alidator
-validators
+[Vv]alidators
+virtualhost
 Wasm
 webRTC
+[Ww]ebsocket
+[Ww]ebsockets
 
 
 

--- a/.github/styles/config/vocabularies/Papermoon/accept.txt
+++ b/.github/styles/config/vocabularies/Papermoon/accept.txt
@@ -1,4 +1,5 @@
 MainNet
+PaperMoon
 TestNet
 time frame
 

--- a/.github/styles/config/vocabularies/Papermoon/reject.txt
+++ b/.github/styles/config/vocabularies/Papermoon/reject.txt
@@ -3,10 +3,7 @@ her
 hers
 him
 his
-let's
-our
 she
-we
 
 
 

--- a/.github/styles/config/vocabularies/Polkadot/accept.txt
+++ b/.github/styles/config/vocabularies/Polkadot/accept.txt
@@ -1,51 +1,26 @@
 Acala
-args
-backchannel
-blockHash
-[Bb]ootnode
-[Bb]ootnodes
-composable
-config
-[Cc]oretime
 Darwinia
 dev_newBlock
 dev_setHead
 dev_setStorage
 dev_timeTravel
-[Dd]ispatchable
-[Ee]xtrinsics
 Ferdie
-[Ff]orkless
-[Ii]nherents
 ink!
 invulnerables
 IPs
 Karura
 Khala
 Kusama
-[Ll]iveness
-[Mm]ultilocation
-[Oo]mninode
-[Pp]arachain
-[Pp]arachain's
-[Pp]arachains
-parathread
 Paseo
 Phala
 Polkadot
 Polkadot's
 Polkadot SDK
-relay chain
-relay chains
+Polkassembly
 Rococo
-[Rr]untimes
 Shiden
 Smoldot
-Solochain
 Subscan
-[Ss]ubxt
-[Ss]udo
-TxWrapper
 Westend
 Zombienet
 


### PR DESCRIPTION
I've learned some new things about how the ignore vs accept lists work that I hope will make flagging more effective, etc. 

Items on the ignore list are ignored by spell check with no case sensitivity. This means no more flagging something like "relay chain" when it's in a heading or having to do [Rr]elay [Cc]hain for every word we add just in case it ends up in a heading🤦🏻‍♀️ 

The accept list enforces case specificity unless you tell it not to. This list is good for things that should nearly always be capitalized like "Polkadot" or similar. 

This PR updates the ignore and vocab lists for Polkadot specific terms according to the above logic. I will take care of the other lists on a separate PR. Thanks! 

