### PR TITLE
Fix - Renaming ci workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,4 +1,4 @@
-name: ci 
+name: Deploy Docs
 on:
   push:
     branches:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,4 +40,5 @@ jobs:
           python -m pip install --upgrade pip setuptools 'cython<3.0.0' wheel
           # install dependencies quietly
           python -m pip install -r requirements.txt
-      - run: mkdocs gh-deploy --force
+      - name: Deploy Docs
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
This PR is intended to rename the `ci.yml` GitHub action to something more descriptive