### PR TITLE
add lightbox plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,9 @@ markdown_extensions:
 plugins:
   - search
   - awesome-pages
+  - glightbox:
+      skip_classes:
+        - no-lightbox
   - redirects:
       redirect_maps:
         # Redirects will go here as pages get moved around in the following format:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ MarkupSafe==2.1.2
 mkdocs==1.6.0
 mkdocs-awesome-pages-plugin==2.8.0
 mkdocs-git-revision-date-localized-plugin==1.2.0
+mkdocs-glightbox==0.4.0
 mkdocs-macros-plugin==0.7.0
 mkdocs-macros-test==0.1.0 
 mkdocs-material==9.5.24


### PR DESCRIPTION
This PR adds lightbox, which allows you to click on an image to quickly zoom in and out to take a closer look. 

⚠️ It introduces a new package, so you'll need to run `pip install -r requirements.txt` after pulling in the changes from this branch.
