### PR TITLE
Enable dedent_subsections feature

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ markdown_extensions:
   - pymdownx.snippets:
       base_path: polkadot-docs/.snippets
       url_download: True
+      dedent_subsections: True
   - pymdownx.tabbed:
       alternate_style: True
   - toc:


### PR DESCRIPTION
Enable `dedent_subsections` feature to remove leading whitespace when pulling code from remote sources