### PR TITLE
[Fix] - Landing page css

### DIFF
--- a/material-overrides/assets/stylesheets/home.css
+++ b/material-overrides/assets/stylesheets/home.css
@@ -1,6 +1,6 @@
 :root {
   --adjust-margin-left: -2em;
-  --adjust-header-height: 8em;
+  --adjust-header-height: 15em;
   --min-padding: 0 3em;
 }
 


### PR DESCRIPTION
This PR solves the following css issue in the desktop version:

<img width="1496" alt="image" src="https://github.com/user-attachments/assets/e9dad96c-4549-4968-b522-892c0767a7ed">

So now, it's rendered as follows: 

<img width="1498" alt="image" src="https://github.com/user-attachments/assets/868ae655-e301-42b6-99aa-5b242c62554b">
