### PR TITLE
Add different icons for indent levels

### DIFF
--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1014,3 +1014,17 @@ details.interface > summary::before {
   top: unset !important; /* To override inline styling */
   bottom: 75px;
 }
+
+/* Custom styles to override MkDocs defaults and enhance theme */
+/* Unordered list <ul> symbols:
+ * - level 2 is hollow circle
+ * - level 3 is filled square
+ * - ul default is filled disc (bullet)
+ */
+ ul ul {
+    list-style-type:  circle !important;
+}
+
+ul ul ul {
+    list-style-type:  square !important;
+}

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1021,10 +1021,10 @@ details.interface > summary::before {
  * - level 3 is filled square
  * - ul default is filled disc (bullet)
  */
- ul ul {
-    list-style-type:  circle !important;
+ ul:not(nav ul) ul {
+    list-style-type: circle !important;
 }
 
-ul ul ul {
-    list-style-type:  square !important;
+ul:not(nav ul) ul ul {
+    list-style-type: square !important;
 }


### PR DESCRIPTION
This PR adds custom styles to override MkDocs defaults and enhance theme
Unordered list symbols added :
- level 1 ul default is filled disc (bullet)
- level 2 is hollow circle
- level 3 is filled square
  