### PR TITLE
Update GitHub pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -43,4 +43,4 @@ jobs:
           # install dependencies quietly
           python -m pip install -r requirements.txt
       - name: Deploy Docs
-        run: mkdocs gh-deploy --force
+        run: mkdocs gh-deploy --force --clean --site-dir ./site


### PR DESCRIPTION
This PR fixes an issue that was introduced by https://github.com/papermoonio/polkadot-mkdocs/pull/33 when we updated the yml file to prepare for launch.

The `site_dir` was set but then this meant that the workflow failed because it can't access `site_dir: /var/www/polkadot-docs-static
`. Therefore a quick fix was just to update the `mkdocs gh-deploy`  command to include a `--site-dir ./site`  which builds it to that directory instead of the one set in the yml file