### PR TITLE
Minor styling fixes for Safari

### DIFF
--- a/material-overrides/assets/stylesheets/home.css
+++ b/material-overrides/assets/stylesheets/home.css
@@ -98,6 +98,7 @@
 
 .md-typeset .button-wrapper a .md-button {
   width: 100%;
+  height: 100%;
 }
 
 .md-typeset iframe.hero-visual {

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -319,6 +319,8 @@
   padding: 0;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   box-shadow: 0 0.2rem 0.5rem #0003, 0 0 0.05rem #00000059;
+   /* For Safari */
+  transform: translateZ(0);
 }
 
 .md-tabs__item {
@@ -969,6 +971,7 @@ input.md-search__input::placeholder {
 
   .md-header__inner {
     margin-left: auto;
+    height: fit-content;
   }
 }
 


### PR DESCRIPTION
This PR fixes the following items:

- Dropdown menus not appearing on Safari
- The pill header remaining the same height on smaller devices on Safari
- The buttons (Join the Community and Start Building) on the home page always rendering as the same height (they were different on a very specific screen size when join the community was broken into two lines)

I checked styling on Safari, Chrome, and Firefox