### PR TITLE
[FIX]- Navbar navigation items

### DIFF
--- a/material-overrides/partials/tabs.html
+++ b/material-overrides/partials/tabs.html
@@ -8,7 +8,9 @@
         {% for nav_item in nav %}
           {% if nav_item.is_section %}
             <li class="md-tabs__item--custom" tabindex="0">    
-              <span class="md-tabs__link">{{ nav_item.title }}</span>
+              <span class="md-tabs__link">
+                <a href="/{{ nav_item.children[0].url}}">{{ nav_item.title }}</a>   
+              </span>
               <ul class="md-tab__list">
                 {% for section_item in nav_item.children %}
                   {% if section_item.is_section %}

--- a/material-overrides/partials/tabs.html
+++ b/material-overrides/partials/tabs.html
@@ -9,7 +9,7 @@
           {% if nav_item.is_section %}
             <li class="md-tabs__item--custom" tabindex="0">    
               <span class="md-tabs__link">
-                <a href="/{{ nav_item.children[0].url}}">{{ nav_item.title }}</a>   
+                <a href="/{{ nav_item.children[0].url }}">{{ nav_item.title }}</a>   
               </span>
               <ul class="md-tab__list">
                 {% for section_item in nav_item.children %}


### PR DESCRIPTION
This PR aims to fix the navigation navbar items, so when you click on any nav item, you get redirected to the index page of that section

**_NOTE: I think that when clicking there, we should also hide the dropdown of each section there, will research a bit about this_**