### PR TITLE
Prepend Polkadot-Mkdocs to Links

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -45,6 +45,6 @@ jobs:
       - name: Update image paths in Markdown files
         run: |
           # Replace old image paths with new paths in Markdown files
-          find polkadot-docs -type f -name "*.md" -exec sed -i 's|(/images/|(/polkadot-mkdocs/images/|g' {} \;
+          find polkadot-docs -type f -name "*.md" -exec sed -i -e 's|](/|](/polkadot-mkdocs/|g' -e 's|href="/|href="/polkadot-mkdocs/|g' {} \;
       - name: Deploy Docs
         run: mkdocs gh-deploy --force --clean --site-dir ./site


### PR DESCRIPTION
GH Pages create a weird issue for URLs and images, this modifies the workflow to fix the issue that was fixed before for images but expand it to general links