### PR TITLE
Add last edited date and edit page button

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,8 @@ site_name: Polkadot Developer Docs
 site_url: https://docs.polkadot.com/
 home_url: https://polkadot.com/
 home_name: Polkadot
+repo_url: https://github.com/polkadot-developers/polkadot-docs
+edit_uri: edit/master
 site_dir: /var/www/polkadot-docs-static
 docs_dir: polkadot-docs
 copyright: © 2024
@@ -35,6 +37,8 @@ theme:
     - navigation.sections # Render top-level sections as groups in the sidebar
     - navigation.indexes # Index pages
     - navigation.top # Show the back to top button since we don't keep top nav sticky
+    - content.action.edit
+    - content.action.view
 markdown_extensions:
   - abbr
   - admonition
@@ -77,6 +81,8 @@ plugins:
   - macros:
       include_yaml:
         - polkadot-docs/variables.yml
+  - git-revision-date-localized:
+      type: date
 extra:
   generator: False
   social:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ extra_javascript:
   - js/header-scroll.js
   - js/search-bar-results.js
   - js/root-level-sections.js
+  - js/fixCreatedDate.js
 # Extra CSS files
 extra_css:
   - assets/stylesheets/extra.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,8 +2,7 @@ site_name: Polkadot Developer Docs
 site_url: https://docs.polkadot.com/
 home_url: https://polkadot.com/
 home_name: Polkadot
-repo_url: https://github.com/polkadot-developers/polkadot-docs
-edit_uri: edit/master
+edit_uri: https://github.com/polkadot-developers/polkadot-docs/edit/master
 site_dir: /var/www/polkadot-docs-static
 docs_dir: polkadot-docs
 copyright: © 2024


### PR DESCRIPTION
This PR adds the last edited date, and buttons to view and modify the page in github.

- Revision date

    <img width="1184" alt="image" src="https://github.com/user-attachments/assets/7176d0b5-558c-4f4e-a1f9-6436bf469370">
    
    Reference: https://henrywhitaker3.github.io/mkdocs-material-dark-theme/plugins/revision-date/

- View and edit buttons

    <img width="745" alt="image" src="https://github.com/user-attachments/assets/806ad800-5369-4a2f-a7e3-28382aedb238">
    
    Reference: https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/?h=content+action#code-actions