### PR TITLE
[FIX] - Termynal element css

### DIFF
--- a/material-overrides/assets/stylesheets/terminal.css
+++ b/material-overrides/assets/stylesheets/terminal.css
@@ -1,5 +1,5 @@
 [data-termynal] {
-  width: 750px;
+  /* width: 750px; */
   max-width: 100%;
   background: #101010;
   color: var(--white);
@@ -40,6 +40,10 @@
 [data-termynal] a,
 .md-typeset [data-termynal] pre {
   color: var(--white);
+}
+
+.md-typeset [data-termynal] pre {
+    white-space: break-spaces;
 }
 
 [data-ty] {

--- a/material-overrides/assets/stylesheets/terminal.css
+++ b/material-overrides/assets/stylesheets/terminal.css
@@ -1,5 +1,4 @@
 [data-termynal] {
-  /* width: 750px; */
   max-width: 100%;
   background: #101010;
   color: var(--white);


### PR DESCRIPTION
This PR seeks to correct the CSS for the rendered termynal element

From:

![image](https://github.com/user-attachments/assets/a56d7c1d-cf10-4fd3-88ea-fd3c004d5f74)

To:

![image](https://github.com/user-attachments/assets/1d61fc85-177c-43d8-8f16-2261aeb9d7d1)


**_Note:_** Please let @eshaben review this PR as we discussed about it :) 