### PR TITLE
configure feedback widget

### DIFF
--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1369,6 +1369,10 @@ details.interface > summary::before {
   color: var(--pink);
 }
 
+.md-feedback__note {
+  font-size: 14px;
+}
+
 /* Styles to override unordered list defaults */
 /* Unordered list <ul> symbols:
  * - level 2 is hollow circle

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,20 +92,20 @@ extra:
     - icon: fontawesome/brands/x-twitter
       link: https://twitter.com/Polkadot
       name: Twitter
-#   analytics:
-#     provider: google
-#     property: G-XXX
-#     feedback:
-#       title: Was this page helpful?
-#       ratings:
-#         - icon: material/emoticon-happy-outline
-#           name: This page was helpful
-#           data: 1
-#           note: >-
-#             Thanks for your feedback!
-#         - icon: material/emoticon-sad-outline
-#           name: This page could be improved
-#           data: 0
-#           note: >-
-#             Thanks for your feedback! Help us improve this page by submitting
-#             <a href="https://github.com/polkadot-developers/polkadot-docs/issues/new/?title=[Feedback]+{title}+-+{url}" target="_blank" rel="noopener">additional feedback</a>.
+  analytics:
+    provider: google
+    property: G-ZSKWB953ZL
+    feedback:
+      title: Was this page helpful?
+      ratings:
+        - icon: material/emoticon-happy-outline
+          name: This page was helpful
+          data: 1
+          note: >-
+            Thanks for your feedback!
+        - icon: material/emoticon-sad-outline
+          name: This page could be improved
+          data: 0
+          note: >-
+            Thanks for your feedback! Help us improve this page by submitting
+            <a href="https://docs.google.com/forms/d/e/1FAIpQLSdZR0p70uR78JVemft66VuL39-k6Mge9rufGZyYBeEhezF3iw/viewform?usp=pp_url&entry.1469237372=[Feedback]+{title}+-+{url}" target="_blank" rel="noopener">additional feedback</a>.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,7 +94,7 @@ extra:
       name: Twitter
   analytics:
     provider: google
-    property: G-ZSKWB953ZL
+    property: G-93CNT1SZV0
     feedback:
       title: Was this page helpful?
       ratings:


### PR DESCRIPTION
This PR adds the GA tag and configures the feedback widget. If a user selects not helpful, they can provide additional feedback via a [google form,](https://docs.google.com/forms/d/e/1FAIpQLSdZR0p70uR78JVemft66VuL39-k6Mge9rufGZyYBeEhezF3iw/viewform?usp=sf_link). The entries are saved in a spreadsheet in our drive