### PR TITLE
Add cookies policy consent modal

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,8 +85,8 @@ extra:
       We use cookies to recognize your repeated visits and preferences, as well as to measure the effectiveness of our documentation.
       By consenting to the use of cookies, you help us improve the site.
     cookies:
-      analytics: Custom name for analytics cookies
-      essential: Essential cookies for site functionality
+      analytics: Google Analythics
+      custom: Essential cookies
     actions:
       - accept
       - manage

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ site_dir: /var/www/polkadot-docs-static
 docs_dir: polkadot-docs
 copyright: © 2024
 extra_javascript:
+  - scripts/cookies-consent.js
   - js/header-scroll.js
   - js/search-bar-results.js
   - js/root-level-sections.js
@@ -78,6 +79,17 @@ plugins:
       include_yaml:
         - polkadot-docs/variables.yml
 extra:
+  consent:
+    title: Cookie Consent
+    description: >-
+      We use cookies to recognize your repeated visits and preferences, as well as to measure the effectiveness of our documentation.
+      By consenting to the use of cookies, you help us improve the site.
+    cookies:
+      analytics: Custom name for analytics cookies
+      essential: Essential cookies for site functionality
+    actions:
+      - accept
+      - manage
   generator: False
   social:
     - icon: fontawesome/brands/discord

--- a/scripts/cookies-consent.js
+++ b/scripts/cookies-consent.js
@@ -1,0 +1,33 @@
+// js/cookie-consent.js
+
+document.addEventListener('DOMContentLoaded', function () {
+    const cookieConsent = document.createElement('div');
+    cookieConsent.id = 'cookie-consent';
+    cookieConsent.innerHTML = `
+        <div class="cookie-banner">
+            <p>${window.mkdocsConfig.extra.consent.description}</p>
+            <button id="accept-cookies">${window.mkdocsConfig.extra.consent.actions[0]}</button>
+            <button id="manage-cookies">${window.mkdocsConfig.extra.consent.actions[1]}</button>
+        </div>
+    `;
+    document.body.appendChild(cookieConsent);
+
+    // Cookie Consent Acceptance
+    const acceptButton = document.getElementById('accept-cookies');
+    acceptButton.addEventListener('click', function () {
+        Cookies.set('cookie-consent', 'accepted', { expires: 365 });
+        cookieConsent.style.display = 'none';
+    });
+
+    // Cookie Consent Management
+    const manageButton = document.getElementById('manage-cookies');
+    manageButton.addEventListener('click', function () {
+        // You can implement your cookie management logic here
+        alert('Manage your cookie settings.');
+    });
+
+    // Check if the user has already accepted cookies
+    if (Cookies.get('cookie-consent') === 'accepted') {
+        cookieConsent.style.display = 'none';
+    }
+});


### PR DESCRIPTION
I added the initial setup consent model for the cookie policy. 

There are a few things that need to be configured before merging the PR:
- Configure Google Analytics cookies (currently commented out in mkdocs.yaml) file
- Additional Cookies (if needed)