### PR TITLE
clean up and update mobile styling and add features for editing pages and document dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,6 @@ Now in the `polkadot-mkdocs` folder, you can build the site by running:
 mkdocs serve
 ```
 
+> **_NOTE:_** To improve build times, you can disable the git revision plugin by running the following command before you serve the docs: `export ENABLED_GIT_REVISION_DATE=false`.
+
 After a successful build, the site should be available locally at `http://127.0.0.1:8000`.

--- a/material-overrides/assets/stylesheets/home.css
+++ b/material-overrides/assets/stylesheets/home.css
@@ -226,6 +226,7 @@
   display: flex;
   justify-content: space-between;
   gap: 3em;
+  margin-bottom: 3em;
 }
 
 .final-cta {

--- a/material-overrides/assets/stylesheets/home.css
+++ b/material-overrides/assets/stylesheets/home.css
@@ -6,7 +6,7 @@
 .home-container {
   background-image: url('../images/gradient.png');
   background-size: 100%;
-  background-repeat: no-repeat; /* Ensures the image doesn't repeat */
+  background-repeat: no-repeat;
   margin-top: calc(
     -1 * var(--adjust-header-height)
   ); /* Use a negative value to push the gradient to cover behind the header */
@@ -15,6 +15,7 @@
   gap: var(--adjust-header-height);
 }
 
+.md-main,
 .md-container {
   padding: 0;
 }
@@ -26,10 +27,6 @@
   width: 100%;
   margin: auto;
   padding: 0 var(--page-padding);
-}
-
-.md-main {
-  padding: 0;
 }
 
 .md-header {
@@ -52,22 +49,12 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  flex-wrap: wrap;
   padding-top: var(--adjust-header-height);
   overflow: hidden;
 }
 
 .hero-content {
   max-width: 44%;
-}
-
-.md-typeset iframe.hero-visual {
-  max-width: 53%;
-}
-
-.md-typeset iframe.hero-visual {
-  transform: scale(1.5);
-  transform-origin: center center;
 }
 
 .md-typeset .hero-content h1 {
@@ -96,8 +83,72 @@
   height: 100%;
 }
 
-.md-typeset iframe.hero-visual {
-  min-height: 35em;
+.tutorial-cards {  
+  width: 44%;
+  display: grid;
+  gap: 1.5em;
+  max-width: 800px;
+  grid-template-rows: auto;
+  grid-auto-rows: minmax(200px, auto);
+  grid-template-columns: 1fr 1fr;
+}
+
+.md-typeset a.tutorial-card {
+  background-color: var(--white);
+  border-radius: 16px;
+  border: 1px solid var(--mystic);
+  padding: 1em;
+  text-decoration: none;
+  position: relative;
+  min-height: 200px;
+}
+
+.md-typeset a.tutorial-card:first-child {
+  grid-row: 1;
+  grid-column: 1;
+}
+
+.md-typeset a.tutorial-card:nth-child(2) {
+  grid-row: 1 / span 2;
+  grid-column: 2;
+  align-self: center;
+  margin-bottom: 1.5em;
+}
+
+.md-typeset a.tutorial-card:nth-child(3) {
+  grid-row: 2;
+  grid-column: 1;
+}
+
+.md-typeset a.tutorial-card:hover h3,
+.md-typeset a.feature:hover h3 {
+  color: var(--pink);
+}
+
+.md-typeset a.tutorial-card .md-icon svg {
+  width: 32px;
+  height: 32px;
+  max-width: unset;
+  fill: var(--black);
+}
+
+.tutorial-card .column:nth-child(2) {
+  display: flex;
+  align-items: center;
+}
+
+.tutorial-card h3 {
+  margin-top: 0;
+  font-size: 20px;
+}
+
+.tutorial-card .tutorial-number {
+  font-size: 22px;
+  vertical-align: bottom;
+}
+
+.tutorial-card p {
+  font-size: 16px;
 }
 
 .feature-intro {
@@ -139,10 +190,6 @@
   line-height: 1.2;
 }
 
-.md-typeset a.feature:hover h3 {
-  color: var(--pink);
-}
-
 .md-typeset .featured-content a {
   text-decoration: none;
   background-color: var(--white);
@@ -176,18 +223,18 @@
 }
 
 .cta-section {
-  padding: 0 var(--min-padding);
+  display: flex;
+  justify-content: space-between;
+  gap: 3em;
 }
 
 .final-cta {
-  width: 880px;
   min-height: 360px;
-  margin: auto;
   border-radius: 16px;
   border: 1px solid var(--mystic);
-  background-size: cover; /* Scales the image to cover the entire element */
-  background-position: center; /* Centers the image */
-  background-repeat: no-repeat; /* Ensures the image doesn't repeat */
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
 .final-cta:first-child {
@@ -199,7 +246,7 @@
 }
 
 .final-cta-content {
-  width: 633px;
+  width: unset;
   min-height: 360px;
   border-radius: 16px;
   background: linear-gradient(
@@ -230,36 +277,26 @@
   margin-top: 1rem;
 }
 
-@media screen and (max-width: 76.2344em) {
+@media screen and (max-width: 76.2344em) {  
   .hero-section {
-    gap: 1em;
-    justify-content: center;
-    flex-direction: column-reverse;
-  }
-
-  .hero-section {
-    padding: var(--min-padding);
-    padding-top: var(--adjust-header-height);
-    padding-bottom: 5em;
-  }
-
-  .hero-content,
-  .md-typeset iframe.hero-visual {
-    max-width: 100%;
-  }
-
-  .md-typeset iframe.hero-visual {
-    min-height: 33em;
+    gap: 3em;
   }
 
   .hero-content {
     justify-items: center;
+    width: unset;
+    max-width: unset;
   }
 
   .md-typeset .hero-content h1 {
     line-height: 1;
     margin-top: 1rem;
     margin-bottom: 2rem;
+  }
+
+  .tutorial-cards {
+    max-width: unset;
+    width: unset;
   }
 
   .feature-intro {
@@ -276,31 +313,38 @@
     max-width: 75%;
   }
 
-  .final-cta {
-    width: 90%;
-  }
-
   .cta-section .final-cta,
   .final-cta-content {
     width: auto;
   }
 }
 
+@media screen and (max-width: 66.2344em) {  
+  .hero-section {
+    flex-wrap: wrap;
+    gap: 5em;
+  }
+
+  .tutorial-cards {
+    grid-auto-rows: auto;
+  }
+
+  .md-typeset a.tutorial-card {
+    min-height: unset;
+  }
+}
+
 @media screen and (max-width: 45em) {
+  .home-container {
+    gap: 4em;
+  }
+
   .hero-section,
   .feature-section,
   .cta-section {
-    padding: 0 1.5rem;
-  }
-
-  .hero-section {
-    padding-top: var(--adjust-header-height);
-    padding-bottom: 5em;
-  }
-
-  .md-typeset iframe.hero-visual {
-    min-height: 18em;
-    max-width: 80%;
+    padding-left: 1.5em;
+    padding-right: 1.5em;
+    word-break: break-word;
   }
 
   .md-typeset .hero-content h1 {
@@ -312,8 +356,25 @@
     width: 100%;
   }
 
-  .feature-section {
-    padding-bottom: 5em;
+  .tutorial-cards {
+    display: flex;
+    flex-direction: column;
+    margin: auto;
+    width: 100%;
+  }
+
+  .tutorial-cards,
+  .featured-content,
+  .cta-section {
+    gap: 36px;
+  }
+
+  .md-typeset a.tutorial-card {
+    width: 100%;
+  }
+
+  .md-typeset a.tutorial-card:nth-child(2) {
+    margin-bottom: 0;
   }
 
   .md-typeset .feature-intro h2 {
@@ -321,8 +382,7 @@
   }
 
   .featured-content {
-    padding: 2em 0;
-    gap: 36px;
+    padding: 0;
   }
 
   .md-typeset a.feature h3 {
@@ -339,6 +399,19 @@
     font-size: 16px;
   }
 
+  .cta-section {
+    flex-direction: column;
+    padding-bottom: 3em;
+  }
+
+  .final-cta {
+    min-height: unset;
+  }
+
+  .final-cta-content {
+    min-height: unset;
+  }  
+
   .md-typeset .final-cta h2 {
     font-size: 1.382rem;
   }
@@ -350,62 +423,4 @@
   .md-typeset .final-cta .md-button {
     margin-top: unset;
   }
-}
-
-
-/** New CSS */
-.tutorial-cards {
-  display: flex;
-  gap: 3em;
-  width: 44%;
-  align-items: center;
-}
-
-.tutorial-cards > .column {
-  display: flex;
-  flex-direction: column;
-  gap: 3em;
-}
-
-.md-typeset a.tutorial-card {
-  background-color: var(--white);
-  border-radius: 16px;
-  border: 1px solid var(--mystic);
-  padding: 1em;
-  display: flex;
-  gap: 24px;
-  text-decoration: none;
-}
-
-.md-typeset a.tutorial-card .md-icon svg {
-  width: 32px;
-  height: 32px;
-  max-width: unset;
-  fill: var(--black);
-}
-
-.tutorial-card .column:nth-child(2) {
-  display: flex;
-  align-items: center;
-}
-
-.tutorial-card h3 {
-  margin-top: 0;
-  font-size: 20px;
-}
-
-.tutorial-card p {
-  font-size: 16px;
-}
-
-.cta-section {
-  display: flex;
-}
-
-.final-cta {
-  width: 45%;
-}
-
-.final-cta-content {
-  width: unset;
 }

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1352,7 +1352,7 @@ details.interface > summary::before {
   padding: 1em;
   border: 1px solid var(--mystic);
   border-radius: 16px;
-  margin: 3rem auto;
+  margin: 1rem auto;
 }
 
 .md-feedback__title {
@@ -1397,6 +1397,12 @@ div.mermaid {
 .md-typeset .grid.cards > ul > li {
   display: flex;
   flex-direction: column;
+  border-radius: 16px;
+}
+
+.md-typeset .grid.cards > ul > li:hover {
+  border: .05rem solid var(--md-default-fg-color--lightest);
+  box-shadow: unset;
 }
 
 .md-typeset .grid.cards > ul > li > :last-child {
@@ -1444,4 +1450,60 @@ div.mermaid {
 .md-typeset span.badge.learn {
   background-color: var(--aqua);
   color: var(--black);
+}
+
+/* Document date styling */
+.md-source-file {
+  display: flex;
+  flex-direction: column;
+}
+
+.md-source-file small {
+  display: flex;
+  justify-content: center;
+}
+
+.source-file-label {
+  margin-right: 0.5em;
+}
+
+.source-file-seperator {
+  margin: 0 0.5em;
+}
+
+/* Edit this page styling */
+.actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 4em;
+}
+
+.md-typeset .actions a {
+  margin: 0;
+  font-size: 80%;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: .5em;
+  color: var(--md-default-fg-color);
+  opacity: .75
+}
+
+.md-typeset .actions svg {
+  fill: var(--heather);
+}
+
+@media screen and (max-width: 30em) {
+  .source-file-seperator {
+    display: none;
+  }
+
+  .actions {
+    margin: 2em auto 0;
+  }
+
+  .md-source-file small {
+    display: block;
+    text-align: center;
+  }
 }

--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -29,15 +29,15 @@
             </div>
           </div>
           <div class="column tutorial-cards">
-            <a class="tutorial-card" href="">
+            <a class="tutorial-card" href="tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template/">
               <h3><span class="tutorial-number">❶</span> Create a chain in minutes</h3>
               <p>Fast-track your development with a preconfigured blockchain template.</p>
             </a>
-            <a class="tutorial-card" href="">
+            <a class="tutorial-card" href="tutorials/polkadot-sdk/parachains/zero-to-hero/build-custom-pallet/">
               <h3><span class="tutorial-number">❷</span> Customize your business logic</h3>
               <p>Design and tailor your blockchain's functionality to fit your needs.</p>
             </a>
-            <a class="tutorial-card" href="">
+            <a class="tutorial-card" href="tutorials/polkadot-sdk/parachains/zero-to-hero/deploy-to-testnet/">
               <h3><span class="tutorial-number">❸</span> Deploy your chain to Polkadot</h3>
               <p>Launch your blockchain on Polkadot's secure and scalable platform.</p>
             </a>

--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -29,37 +29,18 @@
             </div>
           </div>
           <div class="column tutorial-cards">
-            <div class="column">
-              <a class="tutorial-card" href="">
-                <div class="column"> 
-                  <h3>Create a chain in minutes</h3>
-                  <p>Fast-track your development with a preconfigured blockchain template.</p>
-                </div>
-                <div class="column">
-                  <span class="md-icon">{% include ".icons/octicons/arrow-up-right-16.svg" %}</span>
-                </div>
-              </a>
-              <a class="tutorial-card" href="">
-                <div class="column">
-                  <h3>Deploy your chain to Polkadot</h3>
-                  <p>Get your blockchain running on Polkadot's secure and scalable platform.</p>
-                </div>
-                <div class="column">
-                  <span class="md-icon">{% include ".icons/octicons/arrow-up-right-16.svg" %}</span>
-                </div>
-              </a>
-            </div>
-            <div cla class="column"ss="column">
-              <a class="tutorial-card" href="">
-                <div class="column">
-                  <h3>Customize your business logic</h3>
-                  <p>Design and tailor your blockchain's functionality to fit your needs.</p>
-                </div>
-                <div class="column">
-                  <span class="md-icon">{% include ".icons/octicons/arrow-up-right-16.svg" %}</span>
-                </div>
-              </a>
-            </div>
+            <a class="tutorial-card" href="">
+              <h3><span class="tutorial-number">❶</span> Create a chain in minutes</h3>
+              <p>Fast-track your development with a preconfigured blockchain template.</p>
+            </a>
+            <a class="tutorial-card" href="">
+              <h3><span class="tutorial-number">❷</span> Customize your business logic</h3>
+              <p>Design and tailor your blockchain's functionality to fit your needs.</p>
+            </a>
+            <a class="tutorial-card" href="">
+              <h3><span class="tutorial-number">❸</span> Deploy your chain to Polkadot</h3>
+              <p>Launch your blockchain on Polkadot's secure and scalable platform.</p>
+            </a>
           </div>
         </div>
 

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -34,46 +34,6 @@
   {%- endif -%} 
 {%- endblock -%} 
 
-{% block libs %}
-  {{ super() }}
-  <link rel="preconnect" href="https://widget.kapa.ai/">
-  <style data-emotion="mantine" data-s=""></style>
-  <script defer
-    src="https://widget.kapa.ai/kapa-widget.bundle.js"
-    data-website-id="9515d26c-69c3-488d-a9d4-a86e31a9c0e6"
-    data-project-name="Polkadot"
-    data-modal-title="Polkadot AI Chatbot"
-    data-project-color="#1E1E1E"
-    data-button-bg-color="#1C0533"
-    data-button-text-color="white"
-    data-button-height="80px"
-    data-button-width="72px"
-    data-font-size-xs="12px"
-    data-font-size-sm="14px"
-    data-font-size-md="16px"
-    data-font-size-lg="18px"
-    data-font-size-xl="22px"
-    data-modal-title-font-size="22px"
-    data-button-text-font-size="18px"
-    data-query-input-font-size="16px"
-    data-button-image-height="24px"
-    data-button-image-width="24px"
-    data-modal-image-height="24px"
-    data-modal-image-width="24px"
-    data-project-logo="https://1000logos.net/wp-content/uploads/2022/08/Polkadot-Symbol.png"
-    data-modal-header-bg-color="#1C0533"
-    data-modal-title-color="white"
-    data-modal-disclaimer="This is an AI chatbot trained to answer questions about Polkadot. As such, the answers it provides might not always be accurate or up-to-date. Please use your best judgement when evaluating its responses. Also, **please refrain from sharing any personal or private information with the bot**. By submitting a query, you agree that you have read and understood [these conditions](https://polkadot.network/legal-disclosures/).
-      **If you need further assistance, you can reach out to [Polkadot Support](https://support.polkadot.network/support/tickets/new?ticket_form=i_have_a_support_request).**"
-    data-modal-disclaimer-font-size="12px"
-    data-search-mode-enabled="false"
-    data-search-mode-default="false"
-    data-search-result-primary-title-font-size="16px"
-    data-button-position-top="120px"
-    data-button-position-right="0px"
-  ></script>
-{% endblock %}
-
 {%- block container -%} 
   <div class="md-content" data-md-component="content">
     {% set class = "index-page" if not page.content %}

--- a/material-overrides/partials/actions.html
+++ b/material-overrides/partials/actions.html
@@ -1,0 +1,22 @@
+{#-
+    This file was automatically generated - do not edit
+  -#}
+  {% if page.edit_url %}
+    {% if "content.action.edit" in features %}
+      <a href="{{ page.edit_url }}" title="{{ lang.t('action.edit') }}" class="md-content__button md-icon">
+        {% set icon = config.theme.icon.edit or "material/file-edit-outline" %}
+        {% include ".icons/" ~ icon ~ ".svg" %} Edit this page
+      </a>
+    {% endif %}
+    {% if "content.action.view" in features %}
+      {% if "/blob/" in page.edit_url %}
+        {% set part = "blob" %}
+      {% else %}
+        {% set part = "edit" %}
+      {% endif %}
+      <a href="{{ page.edit_url | replace(part, 'raw') }}" title="{{ lang.t('action.view') }}" class="md-content__button md-icon">
+        {% set icon = config.theme.icon.view or "material/file-eye-outline" %}
+        {% include ".icons/" ~ icon ~ ".svg" %}
+      </a>
+    {% endif %}
+  {% endif %}

--- a/material-overrides/partials/content.html
+++ b/material-overrides/partials/content.html
@@ -1,0 +1,15 @@
+{#-
+    This file was automatically generated - do not edit
+  -#}
+  {% if "material/tags" in config.plugins and tags %}
+    {% include "partials/tags.html" %}
+  {% endif %}
+  {% if "\x3ch1" not in page.content %}
+  <h1>{{ page.title | d(config.site_name, true)}}</h1>
+  {% endif %}
+  {{ page.content }}
+  <div class="actions">
+    {% include "partials/actions.html" %}
+  </div>
+  {% include "partials/source-file.html" %}
+  {% include "partials/comments.html" %}

--- a/material-overrides/partials/source-file.html
+++ b/material-overrides/partials/source-file.html
@@ -1,20 +1,23 @@
 {#-
     This file was automatically generated - do not edit
   -#}
-<div class="md-source-file">
-  <small>
-    {% if page.meta.git_revision_date_localized %}
-    <span class="source-file-label">{{ lang.t("source.file.date.updated") }}:</span>
-      {{ page.meta.git_revision_date_localized }}
-      {% if page.meta.git_creation_date_localized %}
-        <br>
-        <span class="source-file-seperator">|</span>
-        <span class="source-file-label">{{ lang.t("source.file.date.created") }}:</span>
-        {{ page.meta.git_creation_date_localized }}
+  <div class="md-source-file">
+    <small>
+      {% if page.meta.git_revision_date_localized %}
+        <span class="source-file-label">{{ lang.t("source.file.date.updated") }}:</span>
+        {{ page.meta.git_revision_date_localized }}
+        {% if page.meta.git_creation_date_localized %}
+          <br>
+          <span class="source-file-seperator">|</span>
+          <span class="source-file-label">{{ lang.t("source.file.date.created") }}:</span>
+          {{ page.meta.git_creation_date_localized }}
+        {% endif %}
+      {% elif page.meta.revision_date %}
+        {{ lang.t("source.file.date.updated") }}:
+        {{ page.meta.revision_date }}
       {% endif %}
-    {% elif page.meta.revision_date %}
-      {{ lang.t("source.file.date.updated") }}:
-      {{ page.meta.revision_date }}
-    {% endif %}
-  </small>
-</div>
+    </small>
+
+    <!-- Was this page helpful? -->
+    {% include "partials/feedback.html" %}
+  </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,7 +94,7 @@ extra:
       name: Twitter
   analytics:
     provider: google
-    property: G-93CNT1SZV0
+    property: G-ZSKWB953ZL
     feedback:
       title: Was this page helpful?
       ratings:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ extra_javascript:
   - js/header-scroll.js
   - js/search-bar-results.js
   - js/root-level-sections.js
-  - js/fixCreatedDate.js
+  - js/fix-created-date.js
 # Extra CSS files
 extra_css:
   - assets/stylesheets/extra.css
@@ -38,7 +38,6 @@ theme:
     - navigation.indexes # Index pages
     - navigation.top # Show the back to top button since we don't keep top nav sticky
     - content.action.edit
-    - content.action.view
 markdown_extensions:
   - abbr
   - admonition
@@ -83,6 +82,10 @@ plugins:
         - polkadot-docs/variables.yml
   - git-revision-date-localized:
       type: date
+      enable_creation_date: true
+      exclude:
+        - node_modules/*
+      # enabled: !ENV [ENABLED_GIT_REVISION_DATE, True]
 extra:
   generator: False
   social:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,7 +85,7 @@ plugins:
       enable_creation_date: true
       exclude:
         - node_modules/*
-      # enabled: !ENV [ENABLED_GIT_REVISION_DATE, True]
+      enabled: !ENV [ENABLED_GIT_REVISION_DATE, True]
 extra:
   generator: False
   social:


### PR DESCRIPTION
This PR does the following:

- Applies mobile styling changes to the home page
- Clean up home page styling
- Add document dates to the bottom of content pages (theres a script that goes with this: https://github.com/polkadot-developers/polkadot-docs/pull/259)
- Add edit this page feature
- Removes kapa configs (temporarily)
- Updates GA tag (based on Thomas' suggestion)