### PR TITLE
Add callout

### DIFF
--- a/policies/cookie-policy.md
+++ b/policies/cookie-policy.md
@@ -57,8 +57,11 @@ Please note that once you correctly block cookies on your browser, parts of the 
 
 | Source           | Cookie  | Domain             | Description                                                                                                                                                                                                                                                                       | Duration                | Type      |
 |------------------|---------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|-----------|
-| Google Analytics | \_ga\_* | .docs.polkadot.com | Google Analytics sets this cookie to store and count page views.                                                                                                                                                                                                                  | 1 year, 1 month, 4 days | Analytics |
-| Google Analytics | \_ga    | .docs.polkadot.com | The \_ga cookie, installed by Google Analytics, calculates visitor, session and campaign data and also keeps track of site usage for the site's analytics report. The cookie stores information anonymously and assigns a randomly generated number to recognize unique visitors. | 1 year, 1 month, 4 days | Analytics |
+| Google Analytics | \_ga\_* | .polkadot.com | Google Analytics sets this cookie to store and count page views.                                                                                                                                                                                                                  | 1 year, 1 month, 4 days | Analytics |
+| Google Analytics | \_ga    | .polkadot.com | The \_ga cookie, installed by Google Analytics, calculates visitor, session and campaign data and also keeps track of site usage for the site's analytics report. The cookie stores information anonymously and assigns a randomly generated number to recognize unique visitors. | 1 year, 1 month, 4 days | Analytics |
+
+!!! note
+    For cookies under the domain `https://polkadot.com`, please refer to Distractive's [Cookie Policy](https://polkadot.com/cookie-policy){target=\_blank}.
 
 ## Changes to This Policy
 


### PR DESCRIPTION
Analytics cookies are actually under the Polkadot.com domain, so adding Distractive callout