### PR TITLE
Add exclude_docs to update sitemap

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,9 @@ extra_css:
 validation:
   absolute_links: ignore
   unrecognized_links: ignore
+exclude_docs: |
+   README.md
+   LICENSE.md
 # Theme related settings
 theme:
   name: material


### PR DESCRIPTION
This PR complements and continues PR#304 from `polkadot-docs `and addresses the addition of Updating the sitemap to reflect the removal of deprecated docs