### PR TITLE
 Center screenshots

### DIFF
--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1529,3 +1529,8 @@ div.mermaid {
     text-align: center;
   }
 }
+/** screnshot styling **/
+.browser-extension {
+  display: block;
+  margin: auto;
+}

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1530,7 +1530,7 @@ div.mermaid {
   }
 }
 /** screnshot styling **/
-.browser-extension {
+img.browser-extension {
   display: block;
   margin: auto;
 }


### PR DESCRIPTION
Update the CSS to add  class `.browser-extension ` to the center screenshots.

This Pr should be merged with the polkadot-docs PR #300 so that the screenshots can be centered.