### PR TITLE
adds styling and config to activate code admonition type 

### DIFF
--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -85,6 +85,10 @@
   --md-mermaid-sequence-note-border-color: var(--md-mermaid-label-fg-color);
   --md-mermaid-sequence-number-bg-color: var(--md-mermaid-node-fg-color);
   --md-mermaid-sequence-number-fg-color: var(--md-accent-bg-color);
+
+/*admonition SVGs*/
+/* SVG run through base64 encoder creates url that goes here*/
+--md-admonition-icon--code: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTE0LjYsMTYuNkwxOS4yLDEyTDE0LjYsNy40TDE2LDZMMjIsMTJMMTYsMThMMTQuNiwxNi42TTkuNCwxNi42TDQuOCwxMkw5LjQsNy40TDgsNkwyLDEyTDgsMThMOS40LDE2LjZaIiAvPjwvc3ZnPg==');
 }
 
 .md-grid {
@@ -1123,6 +1127,26 @@ html .md-footer-meta.md-typeset a:hover {
   color: var(--black);
   text-transform: capitalize;
   padding-left: 0.6666666667em;
+}
+
+/* Code Admonition */
+
+.md-typeset .admonition.code,
+.md-typeset details.code {
+  border-color: var(--md-default-fg-color);
+}
+
+.md-typeset .code > .admonition-title,
+.md-typeset .code > summary {
+  background-color: var(--md-primary-fg-color);
+  color: var(--md-footer-fg-color)
+}
+
+.md-typeset .code > .admonition-title::before,
+.md-typeset .code > summary::before {
+  background-color: var(--md-accent-fg-color);
+  -webkit-mask-image: var(--md-admonition-icon--code);
+  mask-image: var(--md-admonition-icon--code);
 }
 
 /* Child Admonition */

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -5,8 +5,6 @@
   --athens-gray: #eceff3;
   --storm-gray: #6e7391;
   --black: #000000;
-  --code-green: #5ee20c;
-  --code-green-light: #64dd171a;
 
   /* Primary color */
   --pink: #ff2670;
@@ -89,9 +87,10 @@
   --md-mermaid-sequence-number-fg-color: var(--md-accent-bg-color);
 
   /*custom code admonition colors*/
-
-  --md-code-admo-border-color: var(--code-green);
-  --md-code-admo-title-background: var(--code-green-light);
+  
+  --md-code-admo-border-color: #5ee20c;
+  --md-code-admo-title-bg: #64dd171a;
+}
 
 .md-grid {
   max-width: var(--max-page-width);
@@ -1140,7 +1139,7 @@ html .md-footer-meta.md-typeset a:hover {
 
 .md-typeset .code > .admonition-title,
 .md-typeset .code > summary {
-  background-color: var(--md-code-admo-title-background);
+  background-color: var(--md-code-admo-title-bg);
 }
 
 .md-typeset .code > .admonition-title::before,

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -5,6 +5,8 @@
   --athens-gray: #eceff3;
   --storm-gray: #6e7391;
   --black: #000000;
+  --code-green: #5ee20c;
+  --code-green-light: #64dd171a;
 
   /* Primary color */
   --pink: #ff2670;
@@ -86,10 +88,10 @@
   --md-mermaid-sequence-number-bg-color: var(--md-mermaid-node-fg-color);
   --md-mermaid-sequence-number-fg-color: var(--md-accent-bg-color);
 
-/*admonition SVGs*/
-/* SVG run through base64 encoder creates url that goes here*/
---md-admonition-icon--code: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTE0LjYsMTYuNkwxOS4yLDEyTDE0LjYsNy40TDE2LDZMMjIsMTJMMTYsMThMMTQuNiwxNi42TTkuNCwxNi42TDQuOCwxMkw5LjQsNy40TDgsNkwyLDEyTDgsMThMOS40LDE2LjZaIiAvPjwvc3ZnPg==');
-}
+  /*custom code admonition colors*/
+
+  --md-code-admo-border-color: var(--code-green);
+  --md-code-admo-title-background: var(--code-green-light);
 
 .md-grid {
   max-width: var(--max-page-width);
@@ -1133,18 +1135,17 @@ html .md-footer-meta.md-typeset a:hover {
 
 .md-typeset .admonition.code,
 .md-typeset details.code {
-  border-color: var(--md-default-fg-color);
+  border-color: var(--md-code-admo-border-color);
 }
 
 .md-typeset .code > .admonition-title,
 .md-typeset .code > summary {
-  background-color: var(--md-primary-fg-color);
-  color: var(--md-footer-fg-color)
+  background-color: var(--md-code-admo-title-background);
 }
 
 .md-typeset .code > .admonition-title::before,
 .md-typeset .code > summary::before {
-  background-color: var(--md-accent-fg-color);
+  background-color: var(--md-code-admo-border-color);
   -webkit-mask-image: var(--md-admonition-icon--code);
   mask-image: var(--md-admonition-icon--code);
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,9 @@ theme:
   custom_dir: material-overrides
   favicon: assets/images/favicon.webp
   logo: assets/images/logo.webp
+  icon:
+    admonition:
+      code: material/code-tags
   font:
     text: Manrope
   features:


### PR DESCRIPTION
This is my attempt at setting this up for the `code` admonition type for Polkadot. Please feel free to make any changes to the styling, colors used, etc. as this is just a draft. Also, please add any needed CSS for the different screen sizes and stuff. I didn't want to mess with that too much but this will let me see what you do. 

Thank you! 