### PR TITLE
add a badge for external resources

### DIFF
--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1474,6 +1474,11 @@ div.mermaid {
   color: var(--black);
 }
 
+.md-typeset span.badge.external {
+  background-color: var(--blue-ribbon);
+  color: var(--white);
+}
+
 /* Document date styling */
 .md-source-file {
   display: flex;


### PR DESCRIPTION
Add badge to be used for external resources in the "Where to Go Next" sections