### PR TITLE
fix the kapa script

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -72,13 +72,15 @@
     data-button-position-top="120px"
     data-button-position-right="0px"
   ></script>
-  <script>
-    document.body.addEventListener('click', (event) => {
-      if (event.target.id === 'kapa-widget-container') {
-        event.target.addEventListener('keydown', (event) => {
-          event.stopPropagation()
-        })
-      }
+  <script defer>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.body.addEventListener('click', (event) => {
+        if (event.target.id === 'kapa-widget-container') {
+          event.target.addEventListener('keydown', (event) => {
+            event.stopPropagation();
+          });
+        }
+      });
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
This defers the script until all the HTML is parsed and ensures the DOM has been loaded before accessing `document.body`. Ultimately, this should fix the issue where you type in a keyboard shortcut and the page would reload instead of allowing you to type a question to kapa