### PR TITLE
[FEAT] - MetaMask buttons styles

### DIFF
--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1600,3 +1600,23 @@ img.browser-extension {
   display: block;
   margin: auto;
 }
+
+/** MetaMask connection button styling **/
+div.button-wrapper {
+    display: flex;
+    justify-content: center;
+}
+
+div.button-wrapper >
+a.connectMetaMask {
+  background-color: var(--pink);
+  color: var(--white);
+  border: none;
+}
+
+div.button-wrapper >
+a.connectMetaMask:hover {
+  background-color: var(--pink-hover);
+  color: var(--pink);
+  border: 0.06em solid var(--pink);
+}

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1603,20 +1603,10 @@ img.browser-extension {
 
 /** MetaMask connection button styling **/
 div.button-wrapper {
-    display: flex;
-    justify-content: center;
+  display: flex;
+  justify-content: center;
 }
 
-div.button-wrapper >
-a.connectMetaMask {
-  background-color: var(--pink);
-  color: var(--white);
-  border: none;
-}
-
-div.button-wrapper >
-a.connectMetaMask:hover {
-  background-color: var(--pink-hover);
-  color: var(--pink);
-  border: 0.06em solid var(--pink);
+div.button-wrapper > a.connectMetaMask {
+  text-decoration: none;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ extra_javascript:
   - js/search-bar-results.js
   - js/root-level-sections.js
   - js/fix-created-date.js
+  - js/connect-to-metamask.js
 # Extra CSS files
 extra_css:
   - assets/stylesheets/extra.css


### PR DESCRIPTION
This PR adds styles to the MetaMask connection buttons

This goes with: [8f7dea9](https://github.com/polkadot-developers/polkadot-docs/pull/365/commits/8f7dea91cf125bb9d4c5b986e77b0cabff12ccb6)