### PR TITLE
add conditional banner

### DIFF
--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1558,8 +1558,19 @@ div.mermaid {
     text-align: center;
   }
 }
-/** screnshot styling **/
+
+/** Screnshot styling **/
 img.browser-extension {
   display: block;
   margin: auto;
+}
+
+/** Announcement banner styling */
+.announce {
+  z-index: 1;
+}
+
+.md-banner {
+  background-color: var(--mystic);
+  text-align: center;
 }

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1566,7 +1566,7 @@ img.browser-extension {
 }
 
 /** Announcement banner styling */
-.announce {
+.announce.hideable {
   z-index: 1;
 }
 

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -86,10 +86,10 @@
 {% endblock %}
 
 {% block header %}
-  <div data-md-component="announce" class="announce hidden" style="display: none;">
+  {#- With the way the announce partial is set up, we can't override the entire announce div. So this adds one in the header and should be the only one used -#}
+  <div data-md-component="announce" class="announce hideable" style="display: none;">
     <aside class="md-banner">
       <div class="md-banner__inner md-grid md-typeset">
-          <!-- Button to dismiss announcement -->
           <button
             class="md-banner__button md-icon"
             aria-label="{{ lang.t('announce.dismiss') }}"
@@ -97,12 +97,8 @@
             {% set icon = config.theme.icon.close or "material/close" %}
             {% include ".icons/" ~ icon ~ ".svg" %}
           </button>
-        <!-- Announcement bar content -->
         <div class="announce-content">Welcome to the Polkadot developer documentation! If you were looking for docs.substrate.io, you've been redirected here. Check out the <a class="announce-link" href="https://x.com/PolkadotDevs/status/1885377834480230498" target="_blank">official announcement</a> on X (Twitter).</div>
       </div>
-      {% if "announce.dismiss" in features %}
-        {% include "partials/javascripts/announce.html" %}
-      {% endif %}
     </aside>
   </div>
 
@@ -123,15 +119,37 @@
 {% block scripts %}
   {{ super() }}
   <script defer>
-    document.addEventListener('DOMContentLoaded', ()  => {
-      // Check if the referrer contains 'docs.substrate.io'
-      if (document.referrer.includes('docs.substrate.io')) {
-        const announceElement = document.querySelector('.announce.hidden');
-        if (announceElement) {    
-          // Override inline styles to show the banner
-          announceElement.style.display = 'block';
+    document.addEventListener('DOMContentLoaded', () => {
+      if (document.referrer.includes('docs.substrate.io')) {        
+        const announceElement = document.querySelector('.announce.hideable');
+        if (announceElement) {          
+          const content = announceElement.querySelector('.md-typeset');
+          if (content) {            
+            const storedHash = __md_get('__announce');  
+            const currentHash = __md_hash(content.innerHTML);
+
+            const close = document.querySelector('.md-banner__button');
+            if (close) {
+              close.addEventListener('click', () => {                
+                // If the current hash matches the stored value, hide the element
+                if (currentHash === storedHash) {
+                  announceElement.style.display = 'none';
+                  announceElement.hidden = true;
+                } else {
+                  __md_set('__announce', currentHash);
+                  announceElement.style.display = 'none';
+                  announceElement.hidden = true;
+                }
+              });
+            }
+            
+            // Only show the banner if the stored hash doesn't match
+            if (currentHash !== storedHash) {
+              announceElement.style.display = 'block';
+            }
+          }
         }
       }
-    });    
-  </script>
+    });
+  </script>  
 {% endblock %}

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -85,6 +85,30 @@
   </script>
 {% endblock %}
 
+{% block header %}
+  <div data-md-component="announce" class="announce hidden" style="display: none;">
+    <aside class="md-banner">
+      <div class="md-banner__inner md-grid md-typeset">
+          <!-- Button to dismiss announcement -->
+          <button
+            class="md-banner__button md-icon"
+            aria-label="{{ lang.t('announce.dismiss') }}"
+          >
+            {% set icon = config.theme.icon.close or "material/close" %}
+            {% include ".icons/" ~ icon ~ ".svg" %}
+          </button>
+        <!-- Announcement bar content -->
+        <div class="announce-content">Welcome to the Polkadot developer documentation! If you were looking for docs.substrate.io, you've been redirected here. Check out the <a class="announce-link" href="https://x.com/PolkadotDevs/status/1885377834480230498" target="_blank">official announcement</a> on X (Twitter).</div>
+      </div>
+      {% if "announce.dismiss" in features %}
+        {% include "partials/javascripts/announce.html" %}
+      {% endif %}
+    </aside>
+  </div>
+
+  {{ super() }}
+{% endblock %}
+
 {%- block container -%} 
   <div class="md-content" data-md-component="content">
     {% set class = "index-page" if not page.content %}
@@ -95,3 +119,19 @@
     </article>
   </div>
 {%- endblock -%} 
+
+{% block scripts %}
+  {{ super() }}
+  <script defer>
+    document.addEventListener('DOMContentLoaded', ()  => {
+      // Check if the referrer contains 'docs.substrate.io'
+      if (document.referrer.includes('docs.substrate.io')) {
+        const announceElement = document.querySelector('.announce.hidden');
+        if (announceElement) {    
+          // Override inline styles to show the banner
+          announceElement.style.display = 'block';
+        }
+      }
+    });    
+  </script>
+{% endblock %}


### PR DESCRIPTION
This PR adds a conditional banner to the top of the page that only appears after a user has gone to one of the docs.substrate.io pages and was redirected here to the new Polkadot docs, basically just giving them a heads up of like hey you we're redirected here, to find info about the change, check out this twitter post. 

Unfortunately, there's not a more straightforward way to do this because there are no partials that can be overridden and the [announce block](https://github.com/squidfunk/mkdocs-material/blob/44c3b569bf228f44ed515d42b71f7ca1182543eb/src/templates/base.html#L247) just allows you to specify the text and does not include the [entire HTML and JS](https://github.com/squidfunk/mkdocs-material/blob/44c3b569bf228f44ed515d42b71f7ca1182543eb/src/templates/base.html#L229-L254) for the announcement banner.

So I had to essentially duplicate the announcement in the header and manually add the javascript for setting and retrieving the storage element for hiding/showing the announcement bar. 

<img width="1791" alt="Screenshot 2025-02-12 at 4 15 48 PM" src="https://github.com/user-attachments/assets/7c4523e0-b0c4-4c9b-8b9a-fe395ef1e765" />
