### PR TITLE
Update discord link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,7 +106,7 @@ extra:
   generator: False
   social:
     - icon: fontawesome/brands/discord
-      link: https://dot.li/discord
+      link: https://polkadot-discord.w3f.tools
       name: Discord
     - icon: fontawesome/brands/github
       link: https://github.com/paritytech/polkadot-sdk


### PR DESCRIPTION
This PR updates the Discord link because the old one had an issue with the SSL certificate and provided a 404 error.