### PR TITLE
add border on images except for on the home page

### DIFF
--- a/material-overrides/assets/stylesheets/home.css
+++ b/material-overrides/assets/stylesheets/home.css
@@ -45,6 +45,11 @@
   padding-left: 12px;
 }
 
+.md-typeset img {
+  border-radius: unset;
+  box-shadow: unset;
+}
+
 .hero-section {
   display: flex;
   justify-content: space-between;

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1635,3 +1635,8 @@ div.button-wrapper {
 div.button-wrapper > a.connectMetaMask {
   text-decoration: none;
 }
+
+.md-typeset img {
+  border-radius: .5rem;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}


### PR DESCRIPTION
This PR just adds a border around the images, so images with white backgrounds stand out a little bit. Looks like this:

<img width="1075" alt="Screenshot 2025-03-17 at 10 34 34 AM" src="https://github.com/user-attachments/assets/c824c672-ccfc-4556-853e-6b24a7bb89bd" />
