### PR TITLE
fix: pymdownextensions version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ neoteroi-mkdocs==1.1.0
 nltk==3.8.1
 Pillow==11.1.0
 Pygments==2.17.2
-pymdown-extensions==10.7
+pymdown-extensions==10.8.1
 python-dateutil==2.8.2
 PyYAML==6.0.1
 regex==2023.12.25


### PR DESCRIPTION
This PR updates the pymdown-extensions plugin to fix the issue with highlighting. This version (10.8.1) contains this fix -> https://github.com/facelessuser/pymdown-extensions/releases/tag/10.8.1