### PR TITLE
Add support for icons in nav titles

### DIFF
--- a/material-overrides/assets/stylesheets/index-page.css
+++ b/material-overrides/assets/stylesheets/index-page.css
@@ -45,6 +45,15 @@
   padding: 1.05em 1.05em 0em;
 }
 
+.subsection-wrapper .title span {
+  vertical-align: text-top;
+}
+
+.subsection-wrapper .title svg {
+  height: 1rem;
+  margin-right: 0.25em;
+}
+
 .md-typeset hr {
   margin: 0 1.5em 1em;
 }

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -526,9 +526,17 @@ input.md-search__input::placeholder {
 
 /* Nav items with icons in the title */
 .md-nav__link > .nav-title.twemoji {
-  display: flex;
-  align-items: center;
-  gap: .5em;
+  display: inline;
+  white-space: normal;
+}
+
+.md-nav__link .nav-title.twemoji svg {
+  vertical-align: sub;
+  margin: 0 0.5em;
+}
+
+.md-nav__link > .nav-title.twemoji > span svg {
+  margin-left: 0;
 }
 
 @media screen and (min-width: 76.25em) {

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -527,6 +527,7 @@ input.md-search__input::placeholder {
 /* Nav items with icons in the title */
 .md-nav__link > .nav-title.twemoji {
   display: flex;
+  align-items: center;
   gap: .5em;
 }
 

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -524,6 +524,12 @@ input.md-search__input::placeholder {
   margin-left: -1em;
 }
 
+/* Nav items with icons in the title */
+.md-nav__link > .nav-title.twemoji {
+  display: flex;
+  gap: .5em;
+}
+
 @media screen and (min-width: 76.25em) {
   .md-nav {
     font-size: 14px;
@@ -1541,10 +1547,12 @@ span.badge.guide {
   background-color: var(--chartreuse);
   color: var(--black);
 }
+
 span.badge.learn {
   background-color: var(--aqua);
   color: var(--black);
 }
+
 span.badge.external {
   background-color: var(--blue-ribbon);
   color: var(--white);

--- a/material-overrides/index-page.html
+++ b/material-overrides/index-page.html
@@ -5,6 +5,31 @@
   <link rel="stylesheet" href="{{ 'assets/stylesheets/index-page.css' | url }}">
 {% endblock %}
 
+{% macro render_title_with_icon(title) %}
+  {% set parts = title.split(':') %}
+  {% if parts|length > 2 %}
+    {% if parts[0] == '' %}
+      {# Icon is at the start #}
+      {% set icon_name = parts[1] %}
+      {% set text = parts[2] %}
+      <span aria-hidden="true">
+        {% include ".icons/" ~ icon_name.replace('-', '/') ~ ".svg" %}
+      </span>
+      {{ text }}
+    {% else %}
+      {# Icon is at the end #}
+      {% set text = parts[0] %}
+      {% set icon_name = parts[1] %}
+      {{ text }}
+      <span aria-hidden="true">
+        {% include ".icons/" ~ icon_name.replace('-', '/') ~ ".svg" %}
+      </span>
+    {% endif %}
+  {% else %}
+    {{ title }}
+  {% endif %}
+{% endmacro %}
+
 {% macro find_active_page(element, nav) %}
   {% for nav_item in element %}
     {% if nav_item.active %}
@@ -38,7 +63,7 @@
                         {{ nav_item.meta.tutorial_badge | capitalize }}
                       </span>
                     {% endif %}
-                    <h2 class="title">{{ nav_item.title }}</h2>
+                    <h2 class="title" markdown>{{ render_title_with_icon(nav_item.title) }}</h2>
                   </div>
 
                   <hr>

--- a/material-overrides/partials/nav-item.html
+++ b/material-overrides/partials/nav-item.html
@@ -21,7 +21,9 @@
       {% set icon_name = parts[1] %}
       <span class="twemoji nav-title">
         {{ text }}
-        {% include ".icons/" ~ icon_name.replace('-', '/') ~ ".svg" %}
+        <span aria-hidden="true">
+          {% include ".icons/" ~ icon_name.replace('-', '/') ~ ".svg" %}
+        </span>
       </span>
     {% endif %}
   {% else %}

--- a/material-overrides/partials/nav-item.html
+++ b/material-overrides/partials/nav-item.html
@@ -105,9 +105,6 @@
       {% if toc %}
         <label class="md-nav__link md-nav__link--active" for="__toc">
           {{ nav_item.title }}
-          {% if toc | length > 1 %}
-            <span class="md-nav__icon md-icon"></span>
-          {% endif %}
           <span class="md-nav__icon md-icon"></span>
         </label>
       {% endif %}
@@ -128,5 +125,4 @@
     </li>
   {% endif %}
 {% endmacro %}
-
 {{ render(nav_item, path, level) }}

--- a/material-overrides/partials/nav-item.html
+++ b/material-overrides/partials/nav-item.html
@@ -1,6 +1,32 @@
 {#-
   This file was automatically generated - do not edit
 -#}
+
+{% macro render_title_with_icon(title) %}
+  {% set parts = title.split(':') %}
+  {% if parts|length > 2 %}
+    {% if parts[0] == '' %}
+      {# Icon is at the start #}
+      {% set icon_name = parts[1] %}
+      {% set text = parts[2] %}
+      <span class="twemoji nav-title">
+        {% include ".icons/" ~ icon_name.replace('-', '/') ~ ".svg" %}
+        {{ text }}
+      </span>
+    {% else %}
+      {# Icon is at the end #}
+      {% set text = parts[0] %}
+      {% set icon_name = parts[1] %}
+      <span class="twemoji nav-title">
+        {{ text }}
+        {% include ".icons/" ~ icon_name.replace('-', '/') ~ ".svg" %}
+      </span>
+    {% endif %}
+  {% else %}
+    {{ title }}
+  {% endif %}
+{% endmacro %}
+
 {% macro render(nav_item, path, level) %}
   {% set class = "md-nav__item" %}
   {% if nav_item.active %}
@@ -79,12 +105,15 @@
       {% if toc %}
         <label class="md-nav__link md-nav__link--active" for="__toc">
           {{ nav_item.title }}
+          {% if toc | length > 1 %}
+            <span class="md-nav__icon md-icon"></span>
+          {% endif %}
           <span class="md-nav__icon md-icon"></span>
         </label>
       {% endif %}
       <div class="md-nav__link-wrapper {{ class }}">
         <a href="{{ nav_item.url | url }}" class="md-nav__link md-nav__link--active">
-          {{ nav_item.title }}
+          {{ render_title_with_icon(nav_item.title) }}
         </a>
       </div>
       {% if toc %}
@@ -94,9 +123,10 @@
   {% else %}
     <li class="{{ class }}">
       <a href="{{ nav_item.url | url }}" class="md-nav__link">
-        {{ nav_item.title }}
+        {{ render_title_with_icon(nav_item.title) }}
       </a>
     </li>
   {% endif %}
 {% endmacro %}
+
 {{ render(nav_item, path, level) }}

--- a/material-overrides/partials/nav-item.html
+++ b/material-overrides/partials/nav-item.html
@@ -10,7 +10,9 @@
       {% set icon_name = parts[1] %}
       {% set text = parts[2] %}
       <span class="twemoji nav-title">
-        {% include ".icons/" ~ icon_name.replace('-', '/') ~ ".svg" %}
+        <span aria-hidden="true">
+          {% include ".icons/" ~ icon_name.replace('-', '/') ~ ".svg" %}
+        </span>
         {{ text }}
       </span>
     {% else %}


### PR DESCRIPTION
Now in `.pages` files, you can add icons using the following syntax:

```
title: Libraries
nav:
  - index.md
  - 'Ethers.js :simple-javascript:': ethers-js.md
  - 'Web3.js :simple-javascript:': web3-js.md
  - 'Web3.py :simple-python:': web3-py.md
  - 'viem :simple-typescript:': viem.md
  - ':simple-typescript: Wagmi': wagmi.md
```

Which results in:

<img width="289" alt="Screenshot 2025-06-12 at 3 10 39 PM" src="https://github.com/user-attachments/assets/d6b813ba-b6cf-4d05-bcdd-790efb219741" />

You can use any of the icon libraries supported by material for mkdocs: `material`, `octicons`, `simple`, and `fontawesome`