### PR TITLE
disable user tracking via kapa

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -47,6 +47,7 @@
   <style data-emotion="mantine" data-s=""></style>
   <script defer
     src="https://widget.kapa.ai/kapa-widget.bundle.js"
+    data-user-analytics-cookie-enabled="false"
     data-website-id="3fbec0cf-5f4b-4f78-9cff-4ebf071c3bd3"
     data-project-name="Polkadot"
     data-modal-title="Polkadot AI Chatbot"


### PR DESCRIPTION
This disables the new feature Kapa rolled out (which is enabled by default) that adds a first party cookie and tracks users.