### PR TITLE
Fix Anchor Underline

### DIFF
--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -128,6 +128,7 @@
 /* Link styling */
 .md-typeset a {
   text-decoration: underline;
+  text-decoration-skip-ink: none;
 }
 
 .md-typeset a > code {


### PR DESCRIPTION
This pull request introduces a minor update to the `polkadot.css` stylesheet, improving the appearance of underlined links by modifying the text decoration behavior.

Styling update:

* [`material-overrides/assets/stylesheets/polkadot.css`](diffhunk://#diff-a6c8eae84cfc8cfaab7caca9007bb674535981c57b9aaabc22aaa3e08fc62934R131): Added `text-decoration-skip-ink: none;` to `.md-typeset a` to ensure that underlines do not skip over descenders in text, improving visual consistency.
<img width="99" height="37" alt="image" src="https://github.com/user-attachments/assets/69e232cd-a9ab-4b53-b7a9-a1f725d8c711" />
