### PR TITLE
Add copy-to-llm plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,10 @@ markdown_extensions:
 plugins:
   - search
   - awesome-pages
+  - copy-to-llm:
+      enabled: true
+      code_blocks: true
+      page_button: true
   - redirects:
       redirect_maps:
         develop/parachains/testing/setup.md: develop/parachains/testing/index.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Markdown==3.5.2
 MarkupSafe==2.1.3
 mkdocs==1.5.3
 mkdocs-awesome-pages-plugin==2.9.2
+mkdocs-copy-to-llm==0.1.0
 mkdocs-git-revision-date-localized-plugin==1.2.2
 mkdocs-jupyter==0.25.1
 mkdocs-macros-plugin==1.0.5


### PR DESCRIPTION
Hello guys,

Today, I was looking at the Nuxt documentation, and I noticed a button in the top right corner of every single page. I found it very interesting, as not always does an AI have access to a page; most of the time, it fetches the HTML version, which contains a lot of unnecessary information that makes the AI's job harder.

It could be an interesting addition to our documentation. I was going to use their library, but since our documentation is created using "mkdocs", it was not possible. Additionally, I did not find any plugins like this for mkdocs, so I decided to make one myself.

The code can be seen over here: https://github.com/leonardocustodio/mkdocs-copy-to-llm.

It is in a pretty initial stage; you will see a few hardcoded elements, specially made for ourselves. Anyway, I'm posting here first to see what you guys think - if it could be interesting or not to add.

This is a screenshot of how it looks:

<img width="1134" height="857" alt="image" src="https://github.com/user-attachments/assets/11d71d1f-638e-4ed4-9864-182a1939bf18" />
