### PR TITLE
Add New URL in .urlignore

### DIFF
--- a/.urlignore
+++ b/.urlignore
@@ -9,6 +9,9 @@ https://polkadot.com/
 https://fonts.gstatic.com/
 https://fonts.googleapis.com/
 
+# Allowlist known working URLs
+https://metamask.io/
+
 # Ignore sites that block scrapers (403s or 400s)
 https://x.com/
 https://twitter.com/

--- a/.urlignore
+++ b/.urlignore
@@ -9,7 +9,7 @@ https://polkadot.com/
 https://fonts.gstatic.com/
 https://fonts.googleapis.com/
 
-# Allowlist known working URLs
+# Ignore known working URLs
 https://metamask.io/
 
 # Ignore sites that block scrapers (403s or 400s)


### PR DESCRIPTION
This pull request updates the `.urlignore` file to include a new allowlisted URL for improved handling of known working URLs.

* [`.urlignore`](diffhunk://#diff-525d875490887fc8f77ab31d5042dd10415043aefbe000e5290b8a7419730104R12-R14): Added `https://metamask.io/` to the allowlist of known working URLs.