### PR TITLE
Add New URL in .urlignore

### DIFF
--- a/.urlignore
+++ b/.urlignore
@@ -11,6 +11,7 @@ https://fonts.googleapis.com/
 
 # Ignore known working URLs
 https://metamask.io/
+https://ethereum.org/
 
 # Ignore sites that block scrapers (403s or 400s)
 https://x.com/


### PR DESCRIPTION
This pull request updates the `.urlignore` file to include an additional URL in the list of ignored URLs.

* [`.urlignore`](diffhunk://#diff-525d875490887fc8f77ab31d5042dd10415043aefbe000e5290b8a7419730104R14): Added `https://ethereum.org/` to the list of known working URLs to be ignored.