### PR TITLE
[FIX] - Adding `https://certbot.eff.org/` to URL ignore file

### DIFF
--- a/.urlignore
+++ b/.urlignore
@@ -12,6 +12,7 @@ https://fonts.googleapis.com/
 # Ignore known working URLs
 https://metamask.io/
 https://ethereum.org/
+https://certbot.eff.org/
 
 # Ignore sites that block scrapers (403s or 400s)
 https://x.com/


### PR DESCRIPTION
This pull request adds an additional URL to the `.urlignore` file to prevent link checking for a site that is known to work.

* Added `https://certbot.eff.org/` to `.urlignore` to skip link checking for this URL.