### PR TITLE
fix titles with icons in the footer (prev/next)

### DIFF
--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1122,6 +1122,12 @@ html .md-footer-meta.md-typeset a:hover {
   align-items: center;
 }
 
+.md-footer__title .md-ellipsis span svg {
+  width: 1.2em;
+  height: 1.2em;
+  vertical-align: sub;
+}
+
 /* Back to top button */
 [dir="ltr"] .md-top {
   left: 50%;

--- a/material-overrides/index-page.html
+++ b/material-overrides/index-page.html
@@ -1,34 +1,11 @@
 {% extends "main.html" %}
 
+{% from "partials/macros.html" import render_title_with_icon %}
+
 {% block styles %}
   {{ super() }}
   <link rel="stylesheet" href="{{ 'assets/stylesheets/index-page.css' | url }}">
 {% endblock %}
-
-{% macro render_title_with_icon(title) %}
-  {% set parts = title.split(':') %}
-  {% if parts|length > 2 %}
-    {% if parts[0] == '' %}
-      {# Icon is at the start #}
-      {% set icon_name = parts[1] %}
-      {% set text = parts[2] %}
-      <span aria-hidden="true">
-        {% include ".icons/" ~ icon_name.replace('-', '/') ~ ".svg" %}
-      </span>
-      {{ text }}
-    {% else %}
-      {# Icon is at the end #}
-      {% set text = parts[0] %}
-      {% set icon_name = parts[1] %}
-      {{ text }}
-      <span aria-hidden="true">
-        {% include ".icons/" ~ icon_name.replace('-', '/') ~ ".svg" %}
-      </span>
-    {% endif %}
-  {% else %}
-    {{ title }}
-  {% endif %}
-{% endmacro %}
 
 {% macro find_active_page(element, nav) %}
   {% for nav_item in element %}

--- a/material-overrides/partials/footer.html
+++ b/material-overrides/partials/footer.html
@@ -1,6 +1,9 @@
 {#-
     This file was automatically generated - do not edit
   -#}
+
+{% from "partials/macros.html" import render_title_with_icon %}
+
   <footer class="md-footer">
     {% if "navigation.footer" in features %}
       {% if page.previous_page or page.next_page %}
@@ -20,7 +23,7 @@
                   {{ direction }}
                 </span>
                 <div class="md-ellipsis">
-                  {{ page.previous_page.title }}
+                  {{ render_title_with_icon(page.previous_page.title) }}
                 </div>
               </div>
             </a>
@@ -33,7 +36,7 @@
                   {{ direction }}
                 </span>
                 <div class="md-ellipsis">
-                  {{ page.next_page.title }}
+                  {{ render_title_with_icon(page.next_page.title) }}
                 </div>
               </div>
               <div class="md-footer__button md-icon">

--- a/material-overrides/partials/macros.html
+++ b/material-overrides/partials/macros.html
@@ -1,0 +1,46 @@
+{#-
+  Shared macros for Polkadot documentation
+-#}
+
+{% macro render_title_with_icon(title, wrapper_class="") %}
+  {% set parts = title.split(':') %}
+  {% if parts|length > 2 %}
+    {% if parts[0] == '' %}
+      {# Icon is at the start #}
+      {% set icon_name = parts[1] %}
+      {% set text = parts[2] %}
+      {% if wrapper_class %}
+        <span class="{{ wrapper_class }}">
+          <span aria-hidden="true">
+            {% include ".icons/" ~ icon_name.replace('-', '/') ~ ".svg" %}
+          </span>
+          {{ text }}
+        </span>
+      {% else %}
+        <span aria-hidden="true">
+          {% include ".icons/" ~ icon_name.replace('-', '/') ~ ".svg" %}
+        </span>
+        {{ text }}
+      {% endif %}
+    {% else %}
+      {# Icon is at the end #}
+      {% set text = parts[0] %}
+      {% set icon_name = parts[1] %}
+      {% if wrapper_class %}
+        <span class="{{ wrapper_class }}">
+          {{ text }}
+          <span aria-hidden="true">
+            {% include ".icons/" ~ icon_name.replace('-', '/') ~ ".svg" %}
+          </span>
+        </span>
+      {% else %}
+        {{ text }}
+        <span aria-hidden="true">
+          {% include ".icons/" ~ icon_name.replace('-', '/') ~ ".svg" %}
+        </span>
+      {% endif %}
+    {% endif %}
+  {% else %}
+    {{ title }}
+  {% endif %}
+{% endmacro %}

--- a/material-overrides/partials/nav-item.html
+++ b/material-overrides/partials/nav-item.html
@@ -2,34 +2,7 @@
   This file was automatically generated - do not edit
 -#}
 
-{% macro render_title_with_icon(title) %}
-  {% set parts = title.split(':') %}
-  {% if parts|length > 2 %}
-    {% if parts[0] == '' %}
-      {# Icon is at the start #}
-      {% set icon_name = parts[1] %}
-      {% set text = parts[2] %}
-      <span class="twemoji nav-title">
-        <span aria-hidden="true">
-          {% include ".icons/" ~ icon_name.replace('-', '/') ~ ".svg" %}
-        </span>
-        {{ text }}
-      </span>
-    {% else %}
-      {# Icon is at the end #}
-      {% set text = parts[0] %}
-      {% set icon_name = parts[1] %}
-      <span class="twemoji nav-title">
-        {{ text }}
-        <span aria-hidden="true">
-          {% include ".icons/" ~ icon_name.replace('-', '/') ~ ".svg" %}
-        </span>
-      </span>
-    {% endif %}
-  {% else %}
-    {{ title }}
-  {% endif %}
-{% endmacro %}
+{% from "partials/macros.html" import render_title_with_icon %}
 
 {% macro render(nav_item, path, level) %}
   {% set class = "md-nav__item" %}
@@ -114,7 +87,7 @@
       {% endif %}
       <div class="md-nav__link-wrapper {{ class }}">
         <a href="{{ nav_item.url | url }}" class="md-nav__link md-nav__link--active">
-          {{ render_title_with_icon(nav_item.title) }}
+          {{ render_title_with_icon(nav_item.title, "twemoji nav-title") }}
         </a>
       </div>
       {% if toc %}
@@ -124,7 +97,7 @@
   {% else %}
     <li class="{{ class }}">
       <a href="{{ nav_item.url | url }}" class="md-nav__link">
-        {{ render_title_with_icon(nav_item.title) }}
+        {{ render_title_with_icon(nav_item.title, "twemoji nav-title") }}
       </a>
     </li>
   {% endif %}


### PR DESCRIPTION
This pull request adds support for icons in titles in the previous and next section of the footer.  Additionally, minor CSS adjustments were made for better icon alignment in the footer.

<img width="1710" height="158" alt="Screenshot 2025-08-12 at 11 38 51 PM" src="https://github.com/user-attachments/assets/a9c5db31-4190-4ba4-aa42-63e88da9ee23" />


It also refactors how titles with icons are rendered across the documentation site by centralizing the macro logic and improving consistency and maintainability. The main changes include moving the `render_title_with_icon` macro to a shared location, updating all relevant templates to use this shared macro, and enhancing the macro to support custom wrapper classes for styling.
