### PR TITLE
Add a link to the chatbot policy in the footer

### DIFF
--- a/material-overrides/partials/footer.html
+++ b/material-overrides/partials/footer.html
@@ -56,6 +56,7 @@
           <a href="/terms-of-use/">Terms of Use</a>
           <a href="/privacy-policy/">Privacy Policy</a>
           <a href="/cookie-policy/">Cookie Policy</a>
+          <a href="/ai-chatbot-policy/">AI Chatbot Policy</a>
         </div>
         {% if config.extra.social %}
           {% include "partials/social.html" %}


### PR DESCRIPTION
Added a new "AI Chatbot Policy" link to the list of footer policy links in `footer.html`.

Goes with: https://github.com/polkadot-developers/polkadot-docs/pull/899