### PR TITLE
Add redirects for asset transfer API to point to paraspell XCM SDK

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -67,6 +67,18 @@
     {
       "key": "/polkadot-protocol/basics/randomness/",
       "value": "/polkadot-protocol/parachain-basics/randomness/"
+    },
+    {
+      "key": "/develop/toolkit/interoperability/asset-transfer-api/",
+      "value": "/develop/toolkit/interoperability/paraspell-xcm-sdk/"
+    },
+    {
+      "key": "/develop/toolkit/interoperability/asset-transfer-api/overview/",
+      "value": "/develop/toolkit/interoperability/paraspell-xcm-sdk/"
+    },
+    {
+      "key": "/develop/toolkit/interoperability/asset-transfer-api/reference/",
+      "value": "/develop/toolkit/interoperability/paraspell-xcm-sdk/"
     }
   ]
 }


### PR DESCRIPTION
This PR follows up on https://github.com/polkadot-developers/polkadot-docs/pull/914, where the following links were removed in favor of the Paraspell page:
- https://docs.polkadot.com/develop/toolkit/interoperability/asset-transfer-api/
- https://docs.polkadot.com/develop/toolkit/interoperability/asset-transfer-api/overview/
- https://docs.polkadot.com/develop/toolkit/interoperability/asset-transfer-api/reference/

@eshaben, since this is the first time I’m adding these server-side redirects, please let me know if anything else is needed. Thanks in advance!