### PR TITLE
LLMs Overhaul (mkdocs changes)

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -91,64 +91,84 @@
     });
   });
 </script>
-{% endblock %} {% block site_nav %} {#- Navigation (left menu) -#} {% if nav %}
-{% if page.meta and page.meta.hide %} {% set hidden = "hidden" if "navigation"
-in page.meta.hide %} {% endif %}
-<div
-  class="md-sidebar md-sidebar--primary"
-  data-md-component="sidebar"
-  data-md-type="navigation"
-  {{
-  hidden
-  }}
->
-  <div class="md-sidebar__scrollwrap">
-    <div class="md-sidebar__inner">{% include "partials/nav.html" %}</div>
-  </div>
-</div>
-{% endif %} {#- Table of contents (TOC) -#} {% if "toc.integrate" not in
-features %} {% if page.meta and page.meta.hide %} {% set hidden = "hidden" if
-"toc" in page.meta.hide %} {% endif %}
-<div
-  class="md-sidebar md-sidebar--secondary"
-  data-md-component="sidebar"
-  data-md-type="toc"
-  {{
-  hidden
-  }}
->
-  <div class="md-sidebar__scrollwrap">
-    <div class="md-sidebar__inner">
-      {#- TOC -#} {% include "partials/toc.html" %}
-    </div>
+{% endblock %} 
 
-    {#- Feedback and Edit this page container -#}
-    <div class="feedback-actions-container">
-      {#- Feedback Section -#}
-      <div class="feedback-section">{% include "partials/feedback.html" %}</div>
-
-      {#- Edit this Page Section -#}
-      <div class="edit-section">{% include "partials/actions.html" %}</div>
+{% block site_nav %} 
+{#- Navigation (left menu) -#} 
+  {% if nav %}
+    {% if page.meta and page.meta.hide %} 
+      {% set hidden = "hidden" if "navigation" in page.meta.hide %} 
+    {% endif %}
+    <div
+      class="md-sidebar md-sidebar--primary"
+      data-md-component="sidebar"
+      data-md-type="navigation"
+      {{ hidden }}
+    >
+      <div class="md-sidebar__scrollwrap">
+        <div class="md-sidebar__inner">
+          {% include "partials/nav.html" %}
+        </div>
+      </div>
     </div>
-  </div>
-</div>
-{% endif %} {% endblock %} {%- block container -%}
+  {% endif %} 
+  
+  {#- Table of contents (TOC) -#} 
+  {% if "toc.integrate" not in features %} 
+    {% if page.meta and page.meta.hide %} 
+      {% set hidden = "hidden" if "toc" in page.meta.hide %} 
+    {% endif %}
+    <div
+      class="md-sidebar md-sidebar--secondary"
+      data-md-component="sidebar"
+      data-md-type="toc"
+      {{ hidden }}
+    >
+      <div class="md-sidebar__scrollwrap">
+        <div class="md-sidebar__inner">
+          {#- TOC -#} 
+          {% include "partials/toc.html" %}
+        </div>
+
+        {#- Feedback and Edit this page container -#}
+        <div class="feedback-actions-container">
+          {#- Feedback Section -#}
+          <div class="feedback-section">
+            {% include "partials/feedback.html" %}
+          </div>
+
+          {#- Edit this Page Section -#}
+          <div class="edit-section">
+            {% include "partials/actions.html" %}
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endif %} 
+{% endblock %} 
+
+{%- block container -%}
 <div class="md-content" data-md-component="content">
   {% set class = "index-page" if not page.content %}
   <article class="md-content__inner md-typeset {{ class }}">
-    {% block content %} {% include "partials/content.html" %} {% endblock %}
+    {% block content %} 
+      {% include "partials/content.html" %} 
+    {% endblock %}
   </article>
 </div>
-{%- endblock -%} {% block scripts %} {{ super() }}
-<script defer>
-  document.addEventListener('DOMContentLoaded', () => {
-    if (document.referrer.includes('docs.substrate.io')) {
-      const announceElement = document.querySelector('.announce.hideable');
-      if (announceElement) {
-        const content = announceElement.querySelector('.md-typeset');
-        if (content) {
-          const storedHash = __md_get('__announce');
-          const currentHash = __md_hash(content.innerHTML);
+{%- endblock -%} 
+
+{% block scripts %} 
+  {{ super() }}
+  <script defer>
+    document.addEventListener('DOMContentLoaded', () => {
+      if (document.referrer.includes('docs.substrate.io')) {
+        const announceElement = document.querySelector('.announce.hideable');
+        if (announceElement) {
+          const content = announceElement.querySelector('.md-typeset');
+          if (content) {
+            const storedHash = __md_get('__announce');
+            const currentHash = __md_hash(content.innerHTML);
 
           const close = document.querySelector('.md-banner__button');
           if (close) {

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -287,12 +287,6 @@
           downloadViaFetch(url, filename);
         });
       });
-
-      // Special case: llms.txt at site root (same-origin)
-      document.querySelectorAll('.llms-root').forEach((a) => {
-        a.setAttribute('href', `${SITE_BASE}/llms.txt`);
-        a.setAttribute('download', 'llms.txt'); // same-origin, browser will honor
-      });
     });
   </script>
 {% endblock %}

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -195,7 +195,7 @@
     });
   </script>
   <script>
-    // AI_RAW_BASE = base URL where AI artifacts are stored (injected via variables.yml or mkdocs.yml:extra)
+    // AI_RAW_BASE = base URL where AI artifacts are stored (injected via mkdocs.yml:extra)
     const AI_RAW_BASE =
       "{{ config.extra.ai_raw_base | default('https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/master/.ai') }}";
 
@@ -210,6 +210,11 @@
         // 🔧 special-case: root-level llms.txt is served by MkDocs at same origin
         if (dataPath === '/llms.txt' || dataPath === 'llms.txt') {
           return `${SITE_BASE}/llms.txt`;
+        }
+
+        // 🔧 special-case: root-level llms-full.jsonl is served by MkDocs at same origin
+        if (dataPath === '/llms-full.jsonl' || dataPath === 'llms-full.jsonl') {
+          return `${SITE_BASE}/llms-full.jsonl`;
         }
 
         // AI artifacts live under RAW_BASE

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -196,7 +196,7 @@
   </script>
   <script>
     // AI_RAW_BASE = base URL where AI artifacts are stored 
-    const AI_RAW_BASE = "https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/master/.ai'";
+    const AI_RAW_BASE = 'https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/master/.ai';
 
     document.addEventListener('DOMContentLoaded', () => {
       const RAW_BASE = (AI_RAW_BASE).replace(/\/+$/, '');

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -195,12 +195,11 @@
     });
   </script>
   <script>
-    // AI_RAW_BASE = base URL where AI artifacts are stored (injected via mkdocs.yml:extra)
-    const AI_RAW_BASE =
-      "{{ config.extra.ai_raw_base | default('https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/master/.ai') }}";
+    // AI_RAW_BASE = base URL where AI artifacts are stored 
+    const AI_RAW_BASE = "https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/master/.ai'";
 
     document.addEventListener('DOMContentLoaded', () => {
-      const RAW_BASE = (window.AI_RAW_BASE || '').replace(/\/+$/, '');
+      const RAW_BASE = (AI_RAW_BASE).replace(/\/+$/, '');
       const SITE_BASE = location.origin.replace(/\/+$/, '');
 
       const toAbsolute = (dataPath) => {

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -1,257 +1,265 @@
-{% extends "base.html" %}
-
-{% block styles %}
-	{{ super() }}
-  <link rel="stylesheet" href="{{ 'assets/stylesheets/polkadot.css' | url }}">
-{% endblock %}
-
-{% block fonts %}
-  {#-
-    Add Google Fonts here
-  -#}
-  {{ super() }}
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Hammersmith+One&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-{% endblock%}
-
-{% block site_meta %}
-  {{ super() }}
-  {% if page and page.meta and page.meta.keywords %}
-    <meta name="keywords" content="{{ page.meta.keywords }}">
-  {% endif %}
-{% endblock %}
-
-{%- block htmltitle -%} 
-  {%- if page.is_homepage -%} 
-    <title>Draft Docs for Polkadot Ecosystem</title> 
-  {%- elif page and page.meta and page.meta.title -%} 
-    <title>{{ page.meta.title }} | {{ config.site_name }}</title> 
-  {%- elif page and page.title and not page.is_homepage -%} 
-    <title>{{ page.title }} | {{ config.site_name }}</title> 
-  {%- else -%}
-    <title>{{ config.site_name }}</title> 
-  {%- endif -%} 
-{%- endblock -%} 
-
-{% block announce %}
-  <span aria-hidden="true">💬</span> Building with smart contracts? Tell us how we can make your dev experience better 👉 
-  <a href="https://forms.gle/FdmbA7bFSZ4A6Fkz7" target="_blank" rel="noopener noreferrer">
-    Share your thoughts
-  </a>
-{% endblock %}
-
-{% block libs %}
-  {{ super() }}
-  <link rel="preconnect" href="https://widget.kapa.ai/">
-  <style data-emotion="mantine" data-s=""></style>
-  <script defer
-    src="https://widget.kapa.ai/kapa-widget.bundle.js"
-    data-website-id="3fbec0cf-5f4b-4f78-9cff-4ebf071c3bd3"
-    data-user-analytics-cookie-enabled="false"
-    data-project-name="Polkadot"
-    data-modal-title="Polkadot AI Chatbot"
-    data-project-color="#1E1E1E"
-    data-button-bg-color="#1C0533"
-    data-button-text-color="white"
-    data-button-height="80px"
-    data-button-width="72px"
-    data-font-size-xs="12px"
-    data-font-size-sm="14px"
-    data-font-size-md="16px"
-    data-font-size-lg="18px"
-    data-font-size-xl="22px"
-    data-modal-title-font-size="22px"
-    data-button-text-font-size="18px"
-    data-query-input-font-size="16px"
-    data-button-image-height="24px"
-    data-button-image-width="24px"
-    data-modal-image-height="24px"
-    data-modal-image-width="24px"
-    data-project-logo="https://1000logos.net/wp-content/uploads/2022/08/Polkadot-Symbol.png"
-    data-modal-header-bg-color="#1C0533"
-    data-modal-title-color="white"
-    data-modal-disclaimer="This is an AI chatbot trained to answer questions about Polkadot. As such, the answers it provides might not always be accurate or up-to-date. Please use your best judgement when evaluating its responses. Also, **please refrain from sharing any personal or private information with the bot**. By submitting a query, you agree that you have read and understood [these conditions](https://polkadot.com/legal-disclosures/).
+{% extends "base.html" %} {% block styles %} {{ super() }}
+<link rel="stylesheet" href="{{ 'assets/stylesheets/polkadot.css' | url }}" />
+{% endblock %} {% block fonts %} {#- Add Google Fonts here -#} {{ super() }}
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Hammersmith+One&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+  rel="stylesheet"
+/>
+{% endblock%} {% block site_meta %} {{ super() }} {% if page and page.meta and
+page.meta.keywords %}
+<meta name="keywords" content="{{ page.meta.keywords }}" />
+{% endif %} {% endblock %} {%- block htmltitle -%} {%- if page.is_homepage -%}
+<title>Draft Docs for Polkadot Ecosystem</title>
+{%- elif page and page.meta and page.meta.title -%}
+<title>{{ page.meta.title }} | {{ config.site_name }}</title>
+{%- elif page and page.title and not page.is_homepage -%}
+<title>{{ page.title }} | {{ config.site_name }}</title>
+{%- else -%}
+<title>{{ config.site_name }}</title>
+{%- endif -%} {%- endblock -%} {% block announce %}
+<span aria-hidden="true">💬</span> Building with smart contracts? Tell us how we
+can make your dev experience better 👉
+<a
+  href="https://forms.gle/FdmbA7bFSZ4A6Fkz7"
+  target="_blank"
+  rel="noopener noreferrer"
+>
+  Share your thoughts
+</a>
+{% endblock %} {% block libs %} {{ super() }}
+<link rel="preconnect" href="https://widget.kapa.ai/" />
+<style data-emotion="mantine" data-s=""></style>
+<script
+  defer
+  src="https://widget.kapa.ai/kapa-widget.bundle.js"
+  data-website-id="3fbec0cf-5f4b-4f78-9cff-4ebf071c3bd3"
+  data-user-analytics-cookie-enabled="false"
+  data-project-name="Polkadot"
+  data-modal-title="Polkadot AI Chatbot"
+  data-project-color="#1E1E1E"
+  data-button-bg-color="#1C0533"
+  data-button-text-color="white"
+  data-button-height="80px"
+  data-button-width="72px"
+  data-font-size-xs="12px"
+  data-font-size-sm="14px"
+  data-font-size-md="16px"
+  data-font-size-lg="18px"
+  data-font-size-xl="22px"
+  data-modal-title-font-size="22px"
+  data-button-text-font-size="18px"
+  data-query-input-font-size="16px"
+  data-button-image-height="24px"
+  data-button-image-width="24px"
+  data-modal-image-height="24px"
+  data-modal-image-width="24px"
+  data-project-logo="https://1000logos.net/wp-content/uploads/2022/08/Polkadot-Symbol.png"
+  data-modal-header-bg-color="#1C0533"
+  data-modal-title-color="white"
+  data-modal-disclaimer="This is an AI chatbot trained to answer questions about Polkadot. As such, the answers it provides might not always be accurate or up-to-date. Please use your best judgement when evaluating its responses. Also, **please refrain from sharing any personal or private information with the bot**. By submitting a query, you agree that you have read and understood [these conditions](https://polkadot.com/legal-disclosures/).
       **If you need further assistance, you can reach out to [Polkadot Support](https://support.polkadot.network/support/tickets/new?ticket_form=i_have_a_support_request).**"
-    data-modal-disclaimer-font-size="12px"
-    data-search-mode-enabled="false"
-    data-search-mode-default="false"
-    data-search-result-primary-title-font-size="16px"
-    data-button-position-top="120px"
-    data-button-position-right="0px"
-  ></script>
-  <script defer>
-    document.addEventListener('DOMContentLoaded', () => {
-      document.body.addEventListener('click', (event) => {
-        if (event.target.id === 'kapa-widget-container') {
-          event.target.addEventListener('keydown', (event) => {
-            event.stopPropagation();
-          });
+  data-modal-disclaimer-font-size="12px"
+  data-search-mode-enabled="false"
+  data-search-mode-default="false"
+  data-search-result-primary-title-font-size="16px"
+  data-button-position-top="120px"
+  data-button-position-right="0px"
+></script>
+<script defer>
+  document.addEventListener('DOMContentLoaded', () => {
+    document.body.addEventListener('click', (event) => {
+      if (event.target.id === 'kapa-widget-container') {
+        event.target.addEventListener('keydown', (event) => {
+          event.stopPropagation();
+        });
+      }
+    });
+  });
+</script>
+{% endblock %} {% block site_nav %} {#- Navigation (left menu) -#} {% if nav %}
+{% if page.meta and page.meta.hide %} {% set hidden = "hidden" if "navigation"
+in page.meta.hide %} {% endif %}
+<div
+  class="md-sidebar md-sidebar--primary"
+  data-md-component="sidebar"
+  data-md-type="navigation"
+  {{
+  hidden
+  }}
+>
+  <div class="md-sidebar__scrollwrap">
+    <div class="md-sidebar__inner">{% include "partials/nav.html" %}</div>
+  </div>
+</div>
+{% endif %} {#- Table of contents (TOC) -#} {% if "toc.integrate" not in
+features %} {% if page.meta and page.meta.hide %} {% set hidden = "hidden" if
+"toc" in page.meta.hide %} {% endif %}
+<div
+  class="md-sidebar md-sidebar--secondary"
+  data-md-component="sidebar"
+  data-md-type="toc"
+  {{
+  hidden
+  }}
+>
+  <div class="md-sidebar__scrollwrap">
+    <div class="md-sidebar__inner">
+      {#- TOC -#} {% include "partials/toc.html" %}
+    </div>
+
+    {#- Feedback and Edit this page container -#}
+    <div class="feedback-actions-container">
+      {#- Feedback Section -#}
+      <div class="feedback-section">{% include "partials/feedback.html" %}</div>
+
+      {#- Edit this Page Section -#}
+      <div class="edit-section">{% include "partials/actions.html" %}</div>
+    </div>
+  </div>
+</div>
+{% endif %} {% endblock %} {%- block container -%}
+<div class="md-content" data-md-component="content">
+  {% set class = "index-page" if not page.content %}
+  <article class="md-content__inner md-typeset {{ class }}">
+    {% block content %} {% include "partials/content.html" %} {% endblock %}
+  </article>
+</div>
+{%- endblock -%} {% block scripts %} {{ super() }}
+<script defer>
+  document.addEventListener('DOMContentLoaded', () => {
+    if (document.referrer.includes('docs.substrate.io')) {
+      const announceElement = document.querySelector('.announce.hideable');
+      if (announceElement) {
+        const content = announceElement.querySelector('.md-typeset');
+        if (content) {
+          const storedHash = __md_get('__announce');
+          const currentHash = __md_hash(content.innerHTML);
+
+          const close = document.querySelector('.md-banner__button');
+          if (close) {
+            close.addEventListener('click', () => {
+              // If the current hash matches the stored value, hide the element
+              if (currentHash === storedHash) {
+                announceElement.style.display = 'none';
+                announceElement.hidden = true;
+              } else {
+                __md_set('__announce', currentHash);
+                announceElement.style.display = 'none';
+                announceElement.hidden = true;
+              }
+            });
+          }
+
+          // Only show the banner if the stored hash doesn't match
+          if (currentHash !== storedHash) {
+            announceElement.style.display = 'block';
+          }
         }
+      }
+    }
+  });
+</script>
+<script>
+  // AI_RAW_BASE = base URL where AI artifacts are stored (injected via variables.yml or mkdocs.yml:extra)
+  window.AI_RAW_BASE =
+    "{{ config.extra.ai_raw_base | default('https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/master/.ai') }}";
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const RAW_BASE = (window.AI_RAW_BASE || '').replace(/\/+$/, '');
+    const SITE_BASE = location.origin.replace(/\/+$/, '');
+
+    const toAbsolute = (dataPath) => {
+      if (!dataPath) return null;
+      if (/^https?:\/\//i.test(dataPath)) return dataPath; // already absolute
+
+      // 🔧 special-case: root-level llms.txt is served by MkDocs at same origin
+      if (dataPath === '/llms.txt' || dataPath === 'llms.txt') {
+        return `${SITE_BASE}/llms.txt`;
+      }
+
+      // AI artifacts live under RAW_BASE
+      if (dataPath.startsWith('/.ai/')) return `${RAW_BASE}${dataPath}`;
+      if (dataPath.startsWith('/')) return `${RAW_BASE}${dataPath}`;
+      return `${RAW_BASE}/` + dataPath.replace(/^\/+/, '');
+    };
+
+    const downloadViaFetch = async (url, filename) => {
+      try {
+        const res = await fetch(url, { credentials: 'omit' });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const blob = await res.blob(); // keep original content-type from server
+        const link = document.createElement('a');
+        const objectUrl = URL.createObjectURL(blob);
+        link.href = objectUrl;
+        link.download = filename || 'download.txt';
+        document.body.appendChild(link);
+        link.click();
+        URL.revokeObjectURL(objectUrl);
+        link.remove();
+      } catch (err) {
+        console.error('Download failed, falling back to navigation:', err);
+        // Fallback: just navigate to the URL (will open in browser)
+        window.location.href = url;
+      }
+    };
+
+    const copyTextFromUrl = async (url) => {
+      try {
+        const res = await fetch(url, { credentials: 'omit' });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const text = await res.text();
+        await navigator.clipboard.writeText(text);
+
+        const dlg = document.querySelector('.md-dialog');
+        if (dlg) {
+          dlg.classList.add('md-dialog--active');
+          const msg = dlg.querySelector('.md-dialog__inner');
+          if (msg) msg.textContent = "{{ lang.t('clipboard.copied') }}";
+          setTimeout(() => dlg.classList.remove('md-dialog--active'), 2000);
+        }
+      } catch (err) {
+        console.error('Failed to copy:', err);
+        const dlg = document.querySelector('.md-dialog');
+        if (dlg) dlg.classList.remove('md-dialog--active');
+      }
+    };
+
+    // COPY buttons
+    document.querySelectorAll('.llms-copy').forEach((btn) => {
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        const url = toAbsolute(btn.getAttribute('data-path'));
+        if (url) copyTextFromUrl(url);
       });
     });
-  </script>
-{% endblock %}
 
-{% block site_nav %}
-{#- Navigation (left menu) -#}
-  {% if nav %}
-    {% if page.meta and page.meta.hide %}
-      {% set hidden = "hidden" if "navigation" in page.meta.hide %}
-    {% endif %}
-    <div
-      class="md-sidebar md-sidebar--primary"
-      data-md-component="sidebar"
-      data-md-type="navigation"
-      {{ hidden }}
-    >
-      <div class="md-sidebar__scrollwrap">
-        <div class="md-sidebar__inner">
-          {% include "partials/nav.html" %}
-        </div>
-      </div>
-    </div>
-  {% endif %}
-  
-  {#- Table of contents (TOC) -#}
-  {% if "toc.integrate" not in features %}
-    {% if page.meta and page.meta.hide %}
-      {% set hidden = "hidden" if "toc" in page.meta.hide %}
-    {% endif %}
-    <div
-      class="md-sidebar md-sidebar--secondary"
-      data-md-component="sidebar"
-      data-md-type="toc"
-      {{ hidden }}
-    >
-      <div class="md-sidebar__scrollwrap">
-        <div class="md-sidebar__inner">
-          {#- TOC -#}
-          {% include "partials/toc.html" %}
-        </div>
+    // DOWNLOAD buttons: force a real download via Blob
+    document.querySelectorAll('.llms-dl').forEach((a) => {
+      // Set href for right-click "Copy link address" convenience
+      const abs = toAbsolute(a.getAttribute('data-path'));
+      if (abs) a.setAttribute('href', abs);
 
-        {#- Feedback and Edit this page container -#}
-        <div class="feedback-actions-container">
-          {#- Feedback Section -#}
-          <div class="feedback-section">
-            {% include "partials/feedback.html" %}
-          </div>
-
-          {#- Edit this Page Section -#}
-          <div class="edit-section">
-            {% include "partials/actions.html" %}
-          </div>
-        </div>
-      </div>
-    </div>
-  {% endif %}
-{% endblock %}
-
-{%- block container -%} 
-  <div class="md-content" data-md-component="content">
-    {% set class = "index-page" if not page.content %}
-    <article class="md-content__inner md-typeset {{ class }}">
-      {% block content %}
-        {% include "partials/content.html" %}
-      {% endblock %}
-    </article>
-  </div>
-{%- endblock -%} 
-
-{% block scripts %}
-  {{ super() }}
-  <script defer>
-    document.addEventListener('DOMContentLoaded', () => {
-      if (document.referrer.includes('docs.substrate.io')) {        
-        const announceElement = document.querySelector('.announce.hideable');
-        if (announceElement) {          
-          const content = announceElement.querySelector('.md-typeset');
-          if (content) {            
-            const storedHash = __md_get('__announce');  
-            const currentHash = __md_hash(content.innerHTML);
-
-            const close = document.querySelector('.md-banner__button');
-            if (close) {
-              close.addEventListener('click', () => {                
-                // If the current hash matches the stored value, hide the element
-                if (currentHash === storedHash) {
-                  announceElement.style.display = 'none';
-                  announceElement.hidden = true;
-                } else {
-                  __md_set('__announce', currentHash);
-                  announceElement.style.display = 'none';
-                  announceElement.hidden = true;
-                }
-              });
-            }
-            
-            // Only show the banner if the stored hash doesn't match
-            if (currentHash !== storedHash) {
-              announceElement.style.display = 'block';
-            }
-          }
-        }
-      }
+      a.addEventListener('click', (e) => {
+        e.preventDefault();
+        const path = a.getAttribute('data-path') || '';
+        const url = toAbsolute(path);
+        if (!url) return;
+        // Prefer explicit filename; else derive from last path segment
+        const filename =
+          a.getAttribute('data-filename') ||
+          path.split('/').pop() ||
+          'download.txt';
+        downloadViaFetch(url, filename);
+      });
     });
-  </script>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const copyTxtFile = async (url) => {
-        try {
-            const response = await fetch(url);
-            if (!response.ok) {
-              throw new Error(`HTTP error! status: ${response.status}`);
-            }
-            const text = await response.text();
-            await navigator.clipboard.writeText(text);
 
-            const copiedToClipboard = document.querySelector('.md-dialog');
-            if (copiedToClipboard) {
-              copiedToClipboard.classList.add('md-dialog--active');
-
-              const copiedToClipboardMessage =
-                copiedToClipboard.querySelector('.md-dialog__inner');
-              if (
-                copiedToClipboardMessage &&
-                copiedToClipboardMessage.textContent !==
-                  "{{ lang.t('clipboard.copied') }}"
-              ) {
-                copiedToClipboardMessage.textContent =
-                  "{{ lang.t('clipboard.copied') }}";
-              }
-              // Set a timer to remove the dialog after 2 seconds (2000ms)
-              setTimeout(() => {
-                copiedToClipboard.classList.remove('md-dialog--active');
-              }, 2000);
-            }
-          } catch (err) {
-            console.error('Failed to copy:', err);
-            const copiedToClipboard = document.querySelector('.md-dialog');
-            if (copiedToClipboard) {
-              copiedToClipboard.classList.remove('md-dialog--active');
-            }
-          }
-      }
-
-      document.querySelectorAll('.llms').forEach(button => {
-        button.addEventListener('click', (event) => {
-          event.preventDefault(); // Prevent default link behavior
-
-          const action = button.getAttribute('data-action');
-          const fileName = button.getAttribute('data-value');
-          if (!fileName) return; // Exit if no file name is found
-
-          // Add 'llms-files/' prefix except for root-level llms.txt and llms-full.txt
-          const filePath = (fileName === "llms.txt" || fileName === "llms-full.txt") 
-            ? fileName 
-            : `llms-files/${fileName}`;
-          const url = `https://docs.polkadot.com/${filePath}`;
-
-          if (action === 'copy') {
-            copyTxtFile(url);
-          }
-        })
-      })
+    // Special case: llms.txt at site root (same-origin)
+    document.querySelectorAll('.llms-root').forEach((a) => {
+      a.setAttribute('href', `${SITE_BASE}/llms.txt`);
+      a.setAttribute('download', 'llms.txt'); // same-origin, browser will honor
     });
-  </script>
+  });
+</script>
 {% endblock %}

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -73,24 +73,24 @@
     data-modal-title-color="white"
     data-modal-disclaimer="This is an AI chatbot trained to answer questions about Polkadot. As such, the answers it provides might not always be accurate or up-to-date. Please use your best judgement when evaluating its responses. Also, **please refrain from sharing any personal or private information with the bot**. By submitting a query, you agree that you have read and understood [these conditions](https://polkadot.com/legal-disclosures/).
       **If you need further assistance, you can reach out to [Polkadot Support](https://support.polkadot.network/support/tickets/new?ticket_form=i_have_a_support_request).**"
-  data-modal-disclaimer-font-size="12px"
-  data-search-mode-enabled="false"
-  data-search-mode-default="false"
-  data-search-result-primary-title-font-size="16px"
-  data-button-position-top="120px"
-  data-button-position-right="0px"
-></script>
-<script defer>
-  document.addEventListener('DOMContentLoaded', () => {
-    document.body.addEventListener('click', (event) => {
-      if (event.target.id === 'kapa-widget-container') {
-        event.target.addEventListener('keydown', (event) => {
-          event.stopPropagation();
-        });
-      }
+    data-modal-disclaimer-font-size="12px"
+    data-search-mode-enabled="false"
+    data-search-mode-default="false"
+    data-search-result-primary-title-font-size="16px"
+    data-button-position-top="120px"
+    data-button-position-right="0px"
+  ></script>
+  <script defer>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.body.addEventListener('click', (event) => {
+        if (event.target.id === 'kapa-widget-container') {
+          event.target.addEventListener('keydown', (event) => {
+            event.stopPropagation();
+          });
+        }
+      });
     });
-  });
-</script>
+  </script>
 {% endblock %} 
 
 {% block site_nav %} 
@@ -170,129 +170,129 @@
             const storedHash = __md_get('__announce');
             const currentHash = __md_hash(content.innerHTML);
 
-          const close = document.querySelector('.md-banner__button');
-          if (close) {
-            close.addEventListener('click', () => {
-              // If the current hash matches the stored value, hide the element
-              if (currentHash === storedHash) {
-                announceElement.style.display = 'none';
-                announceElement.hidden = true;
-              } else {
-                __md_set('__announce', currentHash);
-                announceElement.style.display = 'none';
-                announceElement.hidden = true;
-              }
-            });
-          }
+            const close = document.querySelector('.md-banner__button');
+            if (close) {
+              close.addEventListener('click', () => {
+                // If the current hash matches the stored value, hide the element
+                if (currentHash === storedHash) {
+                  announceElement.style.display = 'none';
+                  announceElement.hidden = true;
+                } else {
+                  __md_set('__announce', currentHash);
+                  announceElement.style.display = 'none';
+                  announceElement.hidden = true;
+                }
+              });
+            }
 
-          // Only show the banner if the stored hash doesn't match
-          if (currentHash !== storedHash) {
-            announceElement.style.display = 'block';
+            // Only show the banner if the stored hash doesn't match
+            if (currentHash !== storedHash) {
+              announceElement.style.display = 'block';
+            }
           }
         }
       }
-    }
-  });
-</script>
-<script>
-  // AI_RAW_BASE = base URL where AI artifacts are stored (injected via variables.yml or mkdocs.yml:extra)
-  window.AI_RAW_BASE =
-    "{{ config.extra.ai_raw_base | default('https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/master/.ai') }}";
+    });
+  </script>
+  <script>
+    // AI_RAW_BASE = base URL where AI artifacts are stored (injected via variables.yml or mkdocs.yml:extra)
+    const AI_RAW_BASE =
+      "{{ config.extra.ai_raw_base | default('https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/master/.ai') }}";
 
-  document.addEventListener('DOMContentLoaded', () => {
-    const RAW_BASE = (window.AI_RAW_BASE || '').replace(/\/+$/, '');
-    const SITE_BASE = location.origin.replace(/\/+$/, '');
+    document.addEventListener('DOMContentLoaded', () => {
+      const RAW_BASE = (window.AI_RAW_BASE || '').replace(/\/+$/, '');
+      const SITE_BASE = location.origin.replace(/\/+$/, '');
 
-    const toAbsolute = (dataPath) => {
-      if (!dataPath) return null;
-      if (/^https?:\/\//i.test(dataPath)) return dataPath; // already absolute
+      const toAbsolute = (dataPath) => {
+        if (!dataPath) return null;
+        if (/^https?:\/\//i.test(dataPath)) return dataPath; // already absolute
 
-      // 🔧 special-case: root-level llms.txt is served by MkDocs at same origin
-      if (dataPath === '/llms.txt' || dataPath === 'llms.txt') {
-        return `${SITE_BASE}/llms.txt`;
-      }
-
-      // AI artifacts live under RAW_BASE
-      if (dataPath.startsWith('/.ai/')) return `${RAW_BASE}${dataPath}`;
-      if (dataPath.startsWith('/')) return `${RAW_BASE}${dataPath}`;
-      return `${RAW_BASE}/` + dataPath.replace(/^\/+/, '');
-    };
-
-    const downloadViaFetch = async (url, filename) => {
-      try {
-        const res = await fetch(url, { credentials: 'omit' });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const blob = await res.blob(); // keep original content-type from server
-        const link = document.createElement('a');
-        const objectUrl = URL.createObjectURL(blob);
-        link.href = objectUrl;
-        link.download = filename || 'download.txt';
-        document.body.appendChild(link);
-        link.click();
-        URL.revokeObjectURL(objectUrl);
-        link.remove();
-      } catch (err) {
-        console.error('Download failed, falling back to navigation:', err);
-        // Fallback: just navigate to the URL (will open in browser)
-        window.location.href = url;
-      }
-    };
-
-    const copyTextFromUrl = async (url) => {
-      try {
-        const res = await fetch(url, { credentials: 'omit' });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const text = await res.text();
-        await navigator.clipboard.writeText(text);
-
-        const dlg = document.querySelector('.md-dialog');
-        if (dlg) {
-          dlg.classList.add('md-dialog--active');
-          const msg = dlg.querySelector('.md-dialog__inner');
-          if (msg) msg.textContent = "{{ lang.t('clipboard.copied') }}";
-          setTimeout(() => dlg.classList.remove('md-dialog--active'), 2000);
+        // 🔧 special-case: root-level llms.txt is served by MkDocs at same origin
+        if (dataPath === '/llms.txt' || dataPath === 'llms.txt') {
+          return `${SITE_BASE}/llms.txt`;
         }
-      } catch (err) {
-        console.error('Failed to copy:', err);
-        const dlg = document.querySelector('.md-dialog');
-        if (dlg) dlg.classList.remove('md-dialog--active');
-      }
-    };
 
-    // COPY buttons
-    document.querySelectorAll('.llms-copy').forEach((btn) => {
-      btn.addEventListener('click', (e) => {
-        e.preventDefault();
-        const url = toAbsolute(btn.getAttribute('data-path'));
-        if (url) copyTextFromUrl(url);
+        // AI artifacts live under RAW_BASE
+        if (dataPath.startsWith('/.ai/')) return `${RAW_BASE}${dataPath}`;
+        if (dataPath.startsWith('/')) return `${RAW_BASE}${dataPath}`;
+        return `${RAW_BASE}/` + dataPath.replace(/^\/+/, '');
+      };
+
+      const downloadViaFetch = async (url, filename) => {
+        try {
+          const res = await fetch(url, { credentials: 'omit' });
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          const blob = await res.blob(); // keep original content-type from server
+          const link = document.createElement('a');
+          const objectUrl = URL.createObjectURL(blob);
+          link.href = objectUrl;
+          link.download = filename || 'download.txt';
+          document.body.appendChild(link);
+          link.click();
+          URL.revokeObjectURL(objectUrl);
+          link.remove();
+        } catch (err) {
+          console.error('Download failed, falling back to navigation:', err);
+          // Fallback: just navigate to the URL (will open in browser)
+          window.location.href = url;
+        }
+      };
+
+      const copyTextFromUrl = async (url) => {
+        try {
+          const res = await fetch(url, { credentials: 'omit' });
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          const text = await res.text();
+          await navigator.clipboard.writeText(text);
+
+          const dlg = document.querySelector('.md-dialog');
+          if (dlg) {
+            dlg.classList.add('md-dialog--active');
+            const msg = dlg.querySelector('.md-dialog__inner');
+            if (msg) msg.textContent = "{{ lang.t('clipboard.copied') }}";
+            setTimeout(() => dlg.classList.remove('md-dialog--active'), 2000);
+          }
+        } catch (err) {
+          console.error('Failed to copy:', err);
+          const dlg = document.querySelector('.md-dialog');
+          if (dlg) dlg.classList.remove('md-dialog--active');
+        }
+      };
+
+      // COPY buttons
+      document.querySelectorAll('.llms-copy').forEach((btn) => {
+        btn.addEventListener('click', (e) => {
+          e.preventDefault();
+          const url = toAbsolute(btn.getAttribute('data-path'));
+          if (url) copyTextFromUrl(url);
+        });
+      });
+
+      // DOWNLOAD buttons: force a real download via Blob
+      document.querySelectorAll('.llms-dl').forEach((a) => {
+        // Set href for right-click "Copy link address" convenience
+        const abs = toAbsolute(a.getAttribute('data-path'));
+        if (abs) a.setAttribute('href', abs);
+
+        a.addEventListener('click', (e) => {
+          e.preventDefault();
+          const path = a.getAttribute('data-path') || '';
+          const url = toAbsolute(path);
+          if (!url) return;
+          // Prefer explicit filename; else derive from last path segment
+          const filename =
+            a.getAttribute('data-filename') ||
+            path.split('/').pop() ||
+            'download.txt';
+          downloadViaFetch(url, filename);
+        });
+      });
+
+      // Special case: llms.txt at site root (same-origin)
+      document.querySelectorAll('.llms-root').forEach((a) => {
+        a.setAttribute('href', `${SITE_BASE}/llms.txt`);
+        a.setAttribute('download', 'llms.txt'); // same-origin, browser will honor
       });
     });
-
-    // DOWNLOAD buttons: force a real download via Blob
-    document.querySelectorAll('.llms-dl').forEach((a) => {
-      // Set href for right-click "Copy link address" convenience
-      const abs = toAbsolute(a.getAttribute('data-path'));
-      if (abs) a.setAttribute('href', abs);
-
-      a.addEventListener('click', (e) => {
-        e.preventDefault();
-        const path = a.getAttribute('data-path') || '';
-        const url = toAbsolute(path);
-        if (!url) return;
-        // Prefer explicit filename; else derive from last path segment
-        const filename =
-          a.getAttribute('data-filename') ||
-          path.split('/').pop() ||
-          'download.txt';
-        downloadViaFetch(url, filename);
-      });
-    });
-
-    // Special case: llms.txt at site root (same-origin)
-    document.querySelectorAll('.llms-root').forEach((a) => {
-      a.setAttribute('href', `${SITE_BASE}/llms.txt`);
-      a.setAttribute('download', 'llms.txt'); // same-origin, browser will honor
-    });
-  });
-</script>
+  </script>
 {% endblock %}

--- a/material-overrides/partials/footer.html
+++ b/material-overrides/partials/footer.html
@@ -53,7 +53,7 @@
         <div class="row links">
           <div class="llms-links">
             <a href="/llms.txt">llms.txt</a>
-            <a href="https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/master/.ai/llms-full.jsonl">llms-full.JSONL</a>
+            <a href="https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/master/llms-full.jsonl">llms-full.JSONL</a>
             <a href="/get-support/ai-ready-docs/">LLMs by Topic</a>
           </div>
           <div class="policy-links">

--- a/material-overrides/partials/footer.html
+++ b/material-overrides/partials/footer.html
@@ -52,8 +52,9 @@
       <div class="md-footer-meta__inner md-grid">
         <div class="row links">
           <div class="llms-links">
+            <!--TODO: update URL for prod-->
             <a href="/llms.txt">llms.txt</a>
-            <a href="/llms-full.txt">llms-full.txt</a>
+            <a href="https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/refs/heads/dawn/improved-llms/.ai/llms-full.jsonl">Full site JSONL</a>
             <a href="/get-support/ai-ready-docs/">LLMs by Topic</a>
           </div>
           <div class="policy-links">

--- a/material-overrides/partials/footer.html
+++ b/material-overrides/partials/footer.html
@@ -53,7 +53,7 @@
         <div class="row links">
           <div class="llms-links">
             <a href="/llms.txt">llms.txt</a>
-            <a href="https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/master/llms-full.jsonl">llms-full.JSONL</a>
+            <a href="https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/master/llms-full.jsonl">llms-full.jsonl</a>
             <a href="/get-support/ai-ready-docs/">LLMs by Topic</a>
           </div>
           <div class="policy-links">

--- a/material-overrides/partials/footer.html
+++ b/material-overrides/partials/footer.html
@@ -52,9 +52,8 @@
       <div class="md-footer-meta__inner md-grid">
         <div class="row links">
           <div class="llms-links">
-            <!--TODO: update URL for prod-->
             <a href="/llms.txt">llms.txt</a>
-            <a href="https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/refs/heads/dawn/improved-llms/.ai/llms-full.jsonl">Full site JSONL</a>
+            <a href="https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/master/.ai/llms-full.jsonl">llms-full.JSONL</a>
             <a href="/get-support/ai-ready-docs/">LLMs by Topic</a>
           </div>
           <div class="policy-links">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,8 @@ plugins:
         - node_modules/*
       enabled: !ENV [ENABLED_GIT_REVISION_DATE, True]
 extra:
+  # TODO update url for prod
+  ai_raw_base: https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/dawn/improved-llms/.ai
   consent:
     title: Cookie Consent
     description: >-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,8 +97,7 @@ plugins:
         - node_modules/*
       enabled: !ENV [ENABLED_GIT_REVISION_DATE, True]
 extra:
-  # TODO update url for prod
-  ai_raw_base: https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/dawn/improved-llms/.ai
+  ai_raw_base: https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/master/.ai
   consent:
     title: Cookie Consent
     description: >-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,7 +97,6 @@ plugins:
         - node_modules/*
       enabled: !ENV [ENABLED_GIT_REVISION_DATE, True]
 extra:
-  ai_raw_base: https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/master/.ai
   consent:
     title: Cookie Consent
     description: >-


### PR DESCRIPTION
Note: `ai_raw_base` is currently set to my branch for testing purposes and will need to be updated before shipping to prod. 

Goes with: https://github.com/polkadot-developers/polkadot-docs/pull/969

This pull request refactors the AI artifact download and copy logic in the `material-overrides/main.html` template to make it more robust, maintainable, and configurable. It introduces a new configurable base URL for AI artifacts, improves handling of download and copy actions for LLM files, and updates related links in the footer. The changes also include formatting and markup improvements for better readability and maintainability.

### AI artifact handling improvements

* Refactored client-side logic for downloading and copying LLM files: introduced helper functions (`toAbsolute`, `downloadViaFetch`, `copyTextFromUrl`) to handle absolute URL resolution and robust file operations, including error fallback and user feedback.
* Added support for a configurable base URL for AI artifacts using the new `ai_raw_base` variable in `mkdocs.yml`, allowing easy switching between environments. [[1]](diffhunk://#diff-1632ed8257a41f38dd75eb254f77b26ee13443ae895b24aa4305201d38d6b6e6R165-R262) [[2]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R100-R101)

### Footer and link updates

* Updated the footer links to point to the new full-site JSONL file at the AI artifact base URL, and clarified the TODO for production URLs.

### Template formatting and markup improvements => 

(Note: This was part of merge conflicts I needed to clear. I only intend changes to my copy/download scripts so please make sure I cleared the merge conflict properly here).

* Reformatted Jinja blocks and HTML markup in `main.html` for better readability and maintainability, including sidebar, navigation, and content blocks. [[1]](diffhunk://#diff-1632ed8257a41f38dd75eb254f77b26ee13443ae895b24aa4305201d38d6b6e6L1-R35) [[2]](diffhunk://#diff-1632ed8257a41f38dd75eb254f77b26ee13443ae895b24aa4305201d38d6b6e6L94-R129)