### PR TITLE
Add npmjs.com to ignored URLs

### DIFF
--- a/.urlignore
+++ b/.urlignore
@@ -13,6 +13,7 @@ https://fonts.googleapis.com/
 https://metamask.io/
 https://ethereum.org/
 https://certbot.eff.org/
+https://www.npmjs.com/
 
 # Ignore sites that block scrapers (403s or 400s)
 https://x.com/


### PR DESCRIPTION
This pull request makes a minor update to the `.urlignore` file by adding a new URL to the ignore list.

* Added `https://www.npmjs.com/` to the `.urlignore` file to prevent scraping attempts to this site.