### PR TITLE
minor toggle header fix

### DIFF
--- a/material-overrides/assets/stylesheets/toggle-pages.css
+++ b/material-overrides/assets/stylesheets/toggle-pages.css
@@ -21,7 +21,7 @@
   margin-bottom: var(--p-2);
 }
 
-.toggle-header > div:has(h1) {
+.toggle-header div:has(h1) {
   margin-bottom: var(--p-2);
 }
 

--- a/material-overrides/assets/stylesheets/toggle-pages.css
+++ b/material-overrides/assets/stylesheets/toggle-pages.css
@@ -21,6 +21,10 @@
   margin-bottom: var(--p-2);
 }
 
+.toggle-header > div:has(h1) {
+  margin-bottom: var(--p-2);
+}
+
 /* Button container */
 .toggle-buttons {
   display: inline-flex;
@@ -28,6 +32,7 @@
   background: var(--color-border-strong);
   border-radius: var(--rounded-full);
   padding: var(--py-1);
+  margin-top: var(--p-2);
   border: 1px solid var(--color-border);
   width: fit-content;
 }


### PR DESCRIPTION
Splits spacing so it looks the same usually, but when there's a badge now instead of looking like this:

<img width="922" height="393" alt="Screenshot 2026-04-02 at 3 06 07 PM" src="https://github.com/user-attachments/assets/eeef023a-7579-4298-b251-3ac343d4610f" />

It looks like this:

<img width="930" height="402" alt="Screenshot 2026-04-02 at 2 57 24 PM" src="https://github.com/user-attachments/assets/466d8e78-2709-4025-a2b9-4e184f2dfe58" />
