### PR TITLE
Removing Working URL

### DIFF
--- a/.urlignore
+++ b/.urlignore
@@ -15,7 +15,6 @@ https://ethereum.org/
 https://certbot.eff.org/
 https://www.npmjs.com/
 https://wiki.polkadot.com/
-https://en.bitcoin.it/
 
 # Ignore sites that block scrapers (403s or 400s)
 https://x.com/


### PR DESCRIPTION
This pull request makes a minor update to the `.urlignore` file by removing the entry for `https://en.bitcoin.it/`. This means that this URL will no longer be ignored by the relevant tooling or processes.

- Removed `https://en.bitcoin.it/` from the `.urlignore` file.