### PR TITLE
Add page header row and standardize page badges and tests

### DIFF
--- a/material-overrides/assets/stylesheets/ai-file-actions.css
+++ b/material-overrides/assets/stylesheets/ai-file-actions.css
@@ -96,7 +96,6 @@ a.ai-file-actions-btn.single-action-btn {
   display: none;
   position: absolute;
   top: calc(100% + 4px);
-  right: 0;
   background-color: var(--color-surface-secondary);
   border: 1px solid var(--color-border-strong);
   border-radius: var(--rounded);
@@ -142,8 +141,7 @@ tr:has(pre > code):hover pre > code {
   text-decoration: none;
   cursor: pointer;
   transition: background-color 0.1s;
-  font-size: 16px;
-  line-height: 1.2;
+  line-height: 1;
 }
 
 .ai-file-actions-item .ai-file-actions-external {

--- a/material-overrides/assets/stylesheets/ai-file-actions.css
+++ b/material-overrides/assets/stylesheets/ai-file-actions.css
@@ -218,56 +218,18 @@ tr:has(pre > code):hover pre > code {
   }
 }
 
-/* --- Page details row (below H1) --- */
-.page-header-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.4rem;
-  padding-bottom: 0.25rem;
-  border-bottom: 1px solid var(--color-border-strong);
-}
 
-/* Shared style — tutorial badge label and test badge */
-.page-header-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35em;
-  padding: 0.2em 0.4em;
-  color: var(--color-text-secondary);
-  font-size: 0.8em;
-  line-height: 1.4;
-  white-space: nowrap;
-}
-
-.md-typeset a.page-header-item {
-  text-decoration: none;
-  color: var(--color-text-secondary);
-}
-
-.md-typeset a.page-header-item:hover {
-  color: var(--color-text-primary);
-}
-
-.page-header-test-badge img {
-  display: block;
-  height: 1.3em;
-  border-radius: 2px;
-}
-
-/* Dropdown containers — remove outer border and auto-margin */
+/* --- Page header row: ai-file-actions overrides --- */
 .page-header-row .ai-file-actions-container {
   margin-left: 0;
   border: none;
   font-size: 0.8em;
 }
 
-/* Strip the default button background so the trigger is borderless */
 .page-header-row .ai-file-actions-btn {
   background: transparent;
 }
 
-/* Single-button trigger: borderless, icon + text + chevron */
 .page-header-row .ai-file-actions-trigger {
   border: none;
   border-radius: var(--rounded);
@@ -284,7 +246,6 @@ tr:has(pre > code):hover pre > code {
   color: var(--color-text-primary);
 }
 
-/* Scale the chevron down to match the row text size */
 .page-header-row .ai-file-actions-chevron {
   width: 1.1em;
   height: 1.1em;

--- a/material-overrides/assets/stylesheets/ai-file-actions.css
+++ b/material-overrides/assets/stylesheets/ai-file-actions.css
@@ -127,7 +127,8 @@ tr:has(pre > code):hover pre > code {
 }
 
 /* --- Dropdown Items --- */
-.md-typeset a.ai-file-actions-item {
+.md-typeset a.ai-file-actions-item,
+.md-typeset button.ai-file-actions-item {
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -148,7 +149,8 @@ tr:has(pre > code):hover pre > code {
   margin-left: auto;
 }
 
-.md-typeset a.ai-file-actions-item:hover {
+.md-typeset a.ai-file-actions-item:hover,
+.md-typeset button.ai-file-actions-item:hover {
   background-color: var(--color-surface);
   color: var(--color-text-primary);
 }
@@ -213,6 +215,80 @@ tr:has(pre > code):hover pre > code {
     right: auto;
     min-width: 200px;
   }
+}
+
+/* --- Page details row (below H1) --- */
+.page-details {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  padding-bottom: 0.75rem;
+  margin-bottom: 0.75rem;
+  border-bottom: 1px solid var(--color-border-strong);
+}
+
+/* Shared style — tutorial badge label and test badge */
+.page-detail-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  padding: 0.2em 0.4em;
+  color: var(--color-text-secondary);
+  font-size: 0.8em;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.md-typeset a.page-detail-item {
+  text-decoration: none;
+  color: var(--color-text-secondary);
+}
+
+.md-typeset a.page-detail-item:hover {
+  color: var(--color-text-primary);
+}
+
+.page-detail-test-badge img {
+  display: block;
+  height: 1.3em;
+  border-radius: 2px;
+}
+
+/* Dropdown containers — remove outer border and auto-margin */
+.page-details .ai-file-actions-container {
+  margin-left: 0;
+  border: none;
+  font-size: 0.8em;
+}
+
+/* Strip the default button background so the trigger is borderless */
+.page-details .ai-file-actions-btn {
+  background: transparent;
+}
+
+/* Single-button trigger: borderless, icon + text + chevron */
+.page-details .ai-file-actions-trigger {
+  border: none;
+  border-radius: var(--rounded);
+  background: transparent;
+  padding: 0.2em 0.2em 0.2em 0.4em;
+  gap: 0.35em;
+  font-size: inherit;
+  line-height: 1.4;
+  color: var(--color-text-secondary);
+}
+
+.page-details .ai-file-actions-trigger:hover {
+  background: var(--color-surface-secondary);
+  color: var(--color-text-primary);
+}
+
+/* Scale the chevron down to match the row text size */
+.page-details .ai-file-actions-chevron {
+  width: 1.1em;
+  height: 1.1em;
+  min-width: 1.1em;
 }
 
 /* --- Loading Spinner --- */

--- a/material-overrides/assets/stylesheets/ai-file-actions.css
+++ b/material-overrides/assets/stylesheets/ai-file-actions.css
@@ -51,7 +51,8 @@ a.ai-file-actions-btn.single-action-btn {
 }
 
 .ai-file-actions-container:hover .ai-file-actions-copy {
-  border-right-color: var(--color-border-strong); /* Keep separator stable on hover */
+  /* Keep separator stable on hover */
+  border-right-color: var(--color-border-strong);
 }
 
 /* --- Right Button (Trigger) --- */
@@ -112,8 +113,8 @@ a.ai-file-actions-btn.single-action-btn {
 }
 
 /* Reset specific overrides if they exist for the active custom schemes */
-[data-md-color-scheme='custom-light'] .ai-file-actions-container,
-[data-md-color-scheme='custom-dark'] .ai-file-actions-container {
+[data-md-color-scheme="custom-light"] .ai-file-actions-container,
+[data-md-color-scheme="custom-dark"] .ai-file-actions-container {
   border-color: var(--color-border-strong);
 }
 
@@ -218,18 +219,17 @@ tr:has(pre > code):hover pre > code {
 }
 
 /* --- Page details row (below H1) --- */
-.page-details {
+.page-header-row {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 0.4rem;
-  padding-bottom: 0.75rem;
-  margin-bottom: 0.75rem;
+  padding-bottom: 0.25rem;
   border-bottom: 1px solid var(--color-border-strong);
 }
 
 /* Shared style — tutorial badge label and test badge */
-.page-detail-item {
+.page-header-item {
   display: inline-flex;
   align-items: center;
   gap: 0.35em;
@@ -240,35 +240,35 @@ tr:has(pre > code):hover pre > code {
   white-space: nowrap;
 }
 
-.md-typeset a.page-detail-item {
+.md-typeset a.page-header-item {
   text-decoration: none;
   color: var(--color-text-secondary);
 }
 
-.md-typeset a.page-detail-item:hover {
+.md-typeset a.page-header-item:hover {
   color: var(--color-text-primary);
 }
 
-.page-detail-test-badge img {
+.page-header-test-badge img {
   display: block;
   height: 1.3em;
   border-radius: 2px;
 }
 
 /* Dropdown containers — remove outer border and auto-margin */
-.page-details .ai-file-actions-container {
+.page-header-row .ai-file-actions-container {
   margin-left: 0;
   border: none;
   font-size: 0.8em;
 }
 
 /* Strip the default button background so the trigger is borderless */
-.page-details .ai-file-actions-btn {
+.page-header-row .ai-file-actions-btn {
   background: transparent;
 }
 
 /* Single-button trigger: borderless, icon + text + chevron */
-.page-details .ai-file-actions-trigger {
+.page-header-row .ai-file-actions-trigger {
   border: none;
   border-radius: var(--rounded);
   background: transparent;
@@ -279,13 +279,13 @@ tr:has(pre > code):hover pre > code {
   color: var(--color-text-secondary);
 }
 
-.page-details .ai-file-actions-trigger:hover {
+.page-header-row .ai-file-actions-trigger:hover {
   background: var(--color-surface-secondary);
   color: var(--color-text-primary);
 }
 
 /* Scale the chevron down to match the row text size */
-.page-details .ai-file-actions-chevron {
+.page-header-row .ai-file-actions-chevron {
   width: 1.1em;
   height: 1.1em;
   min-width: 1.1em;

--- a/material-overrides/assets/stylesheets/ai-file-actions.css
+++ b/material-overrides/assets/stylesheets/ai-file-actions.css
@@ -79,6 +79,7 @@ a.ai-file-actions-btn.single-action-btn {
 .ai-file-actions-icon.loading-spinner {
   margin: 0;
 }
+
 /* Size and color for the chevron icon */
 .ai-file-actions-chevron {
   background-size: 1em 1em;
@@ -107,10 +108,6 @@ a.ai-file-actions-btn.single-action-btn {
   padding: 5px;
 }
 
-[data-md-color-scheme] .ai-file-actions-menu {
-  border-color: var(--color-border-strong);
-}
-
 /* Reset specific overrides if they exist for the active custom schemes */
 [data-md-color-scheme="custom-light"] .ai-file-actions-container,
 [data-md-color-scheme="custom-dark"] .ai-file-actions-container {
@@ -132,9 +129,7 @@ tr:has(pre > code):hover pre > code {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  width: 100%;
   padding: 0.475rem 0.625rem;
-  border: none;
   background: none;
   color: var(--color-text-primary);
   text-align: left;
@@ -151,7 +146,6 @@ tr:has(pre > code):hover pre > code {
 .md-typeset a.ai-file-actions-item:hover,
 .md-typeset button.ai-file-actions-item:hover {
   background-color: var(--color-surface);
-  color: var(--color-text-primary);
 }
 
 /* --- Table-scoped overrides --- */
@@ -216,7 +210,6 @@ tr:has(pre > code):hover pre > code {
   }
 }
 
-
 /* --- Page header row: ai-file-actions overrides --- */
 .page-header-row .ai-file-actions-container {
   margin-left: 0;
@@ -242,12 +235,6 @@ tr:has(pre > code):hover pre > code {
 .page-header-row .ai-file-actions-trigger:hover {
   background: var(--color-surface-secondary);
   color: var(--color-text-primary);
-}
-
-.page-header-row .ai-file-actions-chevron {
-  width: 1.1em;
-  height: 1.1em;
-  min-width: 1.1em;
 }
 
 /* --- Loading Spinner --- */

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1126,7 +1126,7 @@ span.badge {
   margin-right: 0.5em;
 }
 
-.status-badge > p:first-child {
+.status-badge {
   display: flex;
   flex-direction: column;
   padding-top: var(--p-3);

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1126,6 +1126,32 @@ span.badge {
   margin-right: 0.5em;
 }
 
+.status-badge > p:first-child {
+  display: flex;
+  flex-direction: column;
+  padding-top: var(--p-3);
+  margin: 0;
+  gap: var(--p-1);
+}
+
+a.tests-button {
+  width: fit-content;
+  padding: var(--p-1) var(--p-2);
+  font-size: 14px;
+  text-decoration: none;
+  border-radius: var(--rounded);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-surface-secondary);
+  color: var(--md-default-fg-color);
+  display: flex;
+  gap: var(--p-1);
+  align-items: center;
+}
+
+.md-typeset .status-badge a img {
+  border-radius: var(--rounded);
+}
+
 /* --- Page header row (below H1) --- */
 .page-header-row {
   display: flex;
@@ -1156,12 +1182,15 @@ span.badge {
   color: var(--color-text-primary);
 }
 
-.page-header-test-badge img {
+.md-typeset .page-header-test-badge img {
   display: block;
-  height: 1.3em;
-  border-radius: 2px;
+  height: 1.5em;
+  border-radius: var(--rounded-sm);
 }
 
+.page-header-row + :not(h2) {
+  margin-top: 1.2rem;
+}
 
 /* --- Cards --- */
 .md-typeset .grid.cards {
@@ -1675,4 +1704,3 @@ div.mermaid {
 h1.not-found {
   text-align: center;
 }
-

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1192,6 +1192,14 @@ a.tests-button {
   margin-top: 1.2rem;
 }
 
+.page-header-item-icon {
+  width: 1.1em;
+  height: 1.1em;
+  min-width: 1.1em;
+  fill: currentColor;
+  display: block;
+}
+
 /* --- Cards --- */
 .md-typeset .grid.cards {
   gap: var(--py-3);

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -240,6 +240,7 @@
 .md-typeset h1 {
   line-height: 1.2;
   letter-spacing: -0.02em;
+  margin-bottom: var(--p-4);
 }
 
 .md-typeset h2 {

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1156,7 +1156,6 @@ a.tests-button {
 .page-header-row {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
   gap: 0.4rem;
   padding-bottom: 0.25rem;
   border-bottom: 1px solid var(--color-border-strong);
@@ -1167,7 +1166,6 @@ a.tests-button {
   align-items: center;
   gap: 0.35em;
   padding: 0.2em 0.4em;
-  color: var(--color-text-secondary);
   font-size: 0.8em;
   line-height: 1.4;
   white-space: nowrap;
@@ -1198,6 +1196,13 @@ a.tests-button {
   min-width: 1.1em;
   fill: currentColor;
   display: block;
+}
+
+[data-md-color-scheme="custom-dark"]
+  article.md-content__inner.md-typeset
+  .page-header-test-badge
+  img {
+  border: none;
 }
 
 /* --- Cards --- */

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -240,7 +240,7 @@
 .md-typeset h1 {
   line-height: 1.2;
   letter-spacing: -0.02em;
-  margin-bottom: var(--p-4);
+  margin-bottom: var(--p-2);
 }
 
 .md-typeset h2 {
@@ -668,11 +668,6 @@ label.md-nav__link--active,
 
   .md-nav__icon:hover {
     background-color: transparent;
-  }
-
-  /* Breadcrumbs */
-  .md-path {
-    margin: 0 0.8rem;
   }
 }
 
@@ -1131,32 +1126,42 @@ span.badge {
   margin-right: 0.5em;
 }
 
-/* --- GitHub status badges --- */
-.status-badge > p:first-child {
+/* --- Page header row (below H1) --- */
+.page-header-row {
   display: flex;
-  flex-direction: column;
-  padding-top: var(--p-3);
-  margin: 0;
-  gap: var(--p-1);
-}
-
-.status-badge a > img {
-  border-radius: var(--rounded);
-}
-
-a.tests-button {
-  width: fit-content;
-  padding: var(--p-1) var(--p-2);
-  font-size: 14px;
-  text-decoration: none;
-  border-radius: var(--rounded);
-  border: 1px solid var(--color-border-strong);
-  background: var(--color-surface-secondary);
-  color: var(--md-default-fg-color);
-  display: flex;
-  gap: var(--p-1);
+  flex-wrap: wrap;
   align-items: center;
+  gap: 0.4rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid var(--color-border-strong);
 }
+
+.page-header-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  padding: 0.2em 0.4em;
+  color: var(--color-text-secondary);
+  font-size: 0.8em;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.md-typeset a.page-header-item {
+  text-decoration: none;
+  color: var(--color-text-secondary);
+}
+
+.md-typeset a.page-header-item:hover {
+  color: var(--color-text-primary);
+}
+
+.page-header-test-badge img {
+  display: block;
+  height: 1.3em;
+  border-radius: 2px;
+}
+
 
 /* --- Cards --- */
 .md-typeset .grid.cards {

--- a/material-overrides/assets/stylesheets/toggle-pages.css
+++ b/material-overrides/assets/stylesheets/toggle-pages.css
@@ -21,6 +21,12 @@
   margin-top: 0;
 }
 
+.toggle-header {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--p-3)
+}
+
 /* Button container */
 .toggle-buttons {
   display: inline-flex;
@@ -31,6 +37,7 @@
   margin-bottom: var(--p-2);
   border: 1px solid var(--color-border);
   width: fit-content;
+  height: fit-content;
 }
 
 /* Buttons */
@@ -59,15 +66,4 @@
   border-radius: var(--rounded-full);
   z-index: 1;
   transition: all 0.25s ease;
-}
-
-/* Update the copy-to-llm container margin when used alongside page-level toggle */
-@media screen and (max-width: 768px) {
-  .copy-to-llm-split-container {
-    margin-top: 0;
-  }
-
-  .toggle-buttons {
-    margin-top: 0.2rem;
-  }
 }

--- a/material-overrides/assets/stylesheets/toggle-pages.css
+++ b/material-overrides/assets/stylesheets/toggle-pages.css
@@ -12,9 +12,13 @@
 }
 
 .toggle-panel.active,
-.toggle-header > span.active,
-.page-header-row[data-variant].active {
+.toggle-header > span.active {
   display: block;
+}
+
+.page-header-row[data-variant].active {
+  display: flex;
+  margin-top: 0;
 }
 
 /* Button container */

--- a/material-overrides/assets/stylesheets/toggle-pages.css
+++ b/material-overrides/assets/stylesheets/toggle-pages.css
@@ -17,14 +17,6 @@
   display: block;
 }
 
-.md-typeset .toggle-header h1 {
-  margin-bottom: var(--p-2);
-}
-
-.toggle-header div:has(h1) {
-  margin-bottom: var(--p-2);
-}
-
 /* Button container */
 .toggle-buttons {
   display: inline-flex;

--- a/material-overrides/assets/stylesheets/toggle-pages.css
+++ b/material-overrides/assets/stylesheets/toggle-pages.css
@@ -7,17 +7,17 @@
 /* Panel layout */
 .toggle-panel,
 .toggle-header > span,
-.toggle-header > span .h1-copy-wrapper {
+.page-header-row[data-variant] {
   display: none;
 }
 
 .toggle-panel.active,
-.toggle-header > span.active {
+.toggle-header > span.active,
+.page-header-row[data-variant].active {
   display: block;
 }
 
-.toggle-header > span.active .h1-copy-wrapper {
-  display: flex;
+.md-typeset .toggle-header h1 {
   margin-bottom: var(--p-2);
 }
 
@@ -28,6 +28,7 @@
   background: var(--color-border-strong);
   border-radius: var(--rounded-full);
   padding: var(--py-1);
+  margin-bottom: var(--p-2);
   border: 1px solid var(--color-border);
   width: fit-content;
 }

--- a/material-overrides/partials/content.html
+++ b/material-overrides/partials/content.html
@@ -48,46 +48,62 @@
 {% endif %}
 
 {# ------------------------------------------------------------------ #}
-{# Page details row — rendered directly below the H1                  #}
-{# Contains: tutorial badge, test status badge, ai dropdowns.         #}
+{# Page badges — rendered directly below the H1                       #}
+{# To add a new badge: add a key under page_badges in frontmatter     #}
+{# and handle it in the render_badges macro below.                    #}
+{# To reposition badges, move the render_badges call in the content   #}
+{# rendering section below.                                           #}
 {# ------------------------------------------------------------------ #}
 
-{# Signal-cellular icons for difficulty level #}
+{# Signal-cellular icons for tutorial difficulty level #}
 {% set _ico_cell1 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="ai-file-actions-icon" aria-hidden="true"><path d="M19.5 5.5v13h-2v-13zm-7 5v8h-2v-8zM21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
 {% set _ico_cell2 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="ai-file-actions-icon" aria-hidden="true"><path d="M19.5 5.5v13h-2v-13zM21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
 {% set _ico_cell3 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="ai-file-actions-icon" aria-hidden="true"><path d="M21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
 
-{# --- Assemble the full page-details row --- #}
-{% set page_details_html %}
-<div class="page-details">
-  {%- if page.meta and page.meta.test_workflow -%}
-    {%- set _wf = page.meta.test_workflow | e -%}
-    {%- set _gh = 'https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/' -%}
-    <a class="page-detail-item page-detail-test-badge" href="{{ _gh }}{{ _wf }}.yml" target="_blank" rel="noopener">
-      <img src="{{ _gh }}{{ _wf }}.yml/badge.svg?event=push" alt="Test status">
-    </a>
-  {%- endif -%}
-  {%- if page.meta and page.meta.tutorial_badge -%}
-    {%- set _level = page.meta.tutorial_badge | lower -%}
-    <span class="page-detail-item">
-      {%- if _level == 'beginner' -%}{{ _ico_cell1 }}
-      {%- elif _level == 'intermediate' -%}{{ _ico_cell2 }}
-      {%- elif _level == 'advanced' -%}{{ _ico_cell3 }}
-      {%- endif -%}
-      {{ page.meta.tutorial_badge }}
-    </span>
+{#
+  Renders a .page-header-row row from a page_badges dict.
+  Pass an optional variant string to scope the block with data-variant.
+#}
+{% macro render_badges(badges, variant=None) %}
+<div class="page-header-row"{% if variant %} data-variant="{{ variant | e }}"{% endif %}>
+  {%- if badges -%}
+    {%- if badges.test_workflow -%}
+      {%- set _wf = badges.test_workflow | e -%}
+      {%- set _gh = 'https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/' -%}
+      <a class="page-header-item page-header-test-badge" href="{{ _gh }}{{ _wf }}.yml" target="_blank" rel="noopener">
+        <img src="{{ _gh }}{{ _wf }}.yml/badge.svg?event=push" alt="Test status">
+      </a>
+    {%- endif -%}
+    {%- if badges.tutorial_badge -%}
+      {%- set _level = badges.tutorial_badge | lower -%}
+      <span class="page-header-item">
+        {%- if _level == 'beginner' -%}{{ _ico_cell1 }}
+        {%- elif _level == 'intermediate' -%}{{ _ico_cell2 }}
+        {%- elif _level == 'advanced' -%}{{ _ico_cell3 }}
+        {%- endif -%}
+        {{ badges.tutorial_badge }}
+      </span>
+    {%- endif -%}
   {%- endif -%}
 </div>
-{% endset %}
+{% endmacro %}
 
 {# ------------------------------------------------------------------ #}
 {# Content rendering                                                    #}
 {# ------------------------------------------------------------------ #}
 
-{% if "\x3ch1" in page.content %}
-  {% set rendered_content = page.content | replace('</h1>', '</h1>' ~ page_details_html, 1) %}
+{% if page.meta.toggle_variant_metas %}
+  {# Toggle page: replace the plugin-inserted placeholder with per-variant badge blocks #}
+  {% set badge_blocks %}
+    {%- for variant, badges in page.meta.toggle_variant_metas -%}
+      {{- render_badges(badges, variant) -}}
+    {%- endfor -%}
+  {% endset %}
+  {% set rendered_content = page.content | replace('<!-- toggle-badges -->', badge_blocks, 1) %}
+{% elif "\x3ch1" in page.content %}
+  {% set rendered_content = page.content | replace('</h1>', '</h1>' ~ render_badges(page.meta.page_badges), 1) %}
 {% else %}
-  {% set rendered_content = '<h1>' ~ (page.title | d(config.site_name, true)) ~ '</h1>' ~ page_details_html ~ page.content %}
+  {% set rendered_content = '<h1>' ~ (page.title | d(config.site_name, true)) ~ '</h1>' ~ render_badges(page.meta.page_badges) ~ page.content %}
 {% endif %}
 
 {% if "faq" in page.url %}

--- a/material-overrides/partials/content.html
+++ b/material-overrides/partials/content.html
@@ -47,15 +47,8 @@
   {% include "partials/tags.html" %}
 {% endif %}
 
-{# ------------------------------------------------------------------ #}
-{# Page badges — rendered directly below the H1                       #}
-{# To add a new badge: add a key under page_badges in frontmatter     #}
-{# and handle it in the render_badges macro below.                    #}
-{# To reposition badges, move the render_badges call in the content   #}
-{# rendering section below.                                           #}
-{# ------------------------------------------------------------------ #}
-
 {% from "partials/page-badges.html" import render_badges %}
+{% from "partials/page-tests.html" import render_test_block %}
 
 {# ------------------------------------------------------------------ #}
 {# Content rendering                                                    #}
@@ -73,6 +66,22 @@
   {% set rendered_content = page.content | replace('</h1>', '</h1>' ~ render_badges(page.meta.page_badges), 1) %}
 {% else %}
   {% set rendered_content = '<h1>' ~ (page.title | d(config.site_name, true)) ~ '</h1>' ~ render_badges(page.meta.page_badges) ~ page.content %}
+{% endif %}
+
+{# ------------------------------------------------------------------ #}
+{# Page tests block — injected before "Where to Go Next" or at end    #}
+{# Driven by page_tests.path in frontmatter; uses page_badges         #}
+{# .test_workflow (if set) for the CI badge image.                    #}
+{# ------------------------------------------------------------------ #}
+{% if page.meta.page_tests and page.meta.page_tests.path %}
+  {%- set _wf = page.meta.page_badges.test_workflow if page.meta.page_badges and page.meta.page_badges.test_workflow else None -%}
+  {%- set _test_block = render_test_block(_wf, page.meta.page_tests.path, page.title) -%}
+  {%- set _wtgn_marker = '<h2 id="where-to-go-next"' -%}
+  {%- if _wtgn_marker in rendered_content -%}
+    {%- set rendered_content = rendered_content | replace(_wtgn_marker, _test_block ~ _wtgn_marker, 1) -%}
+  {%- else -%}
+    {%- set rendered_content = rendered_content ~ _test_block -%}
+  {%- endif -%}
 {% endif %}
 
 {% if "faq" in page.url %}

--- a/material-overrides/partials/content.html
+++ b/material-overrides/partials/content.html
@@ -55,38 +55,7 @@
 {# rendering section below.                                           #}
 {# ------------------------------------------------------------------ #}
 
-{# Signal-cellular icons for tutorial difficulty level #}
-{% set _ico_cell1 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="ai-file-actions-icon" aria-hidden="true"><path d="M19.5 5.5v13h-2v-13zm-7 5v8h-2v-8zM21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
-{% set _ico_cell2 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="ai-file-actions-icon" aria-hidden="true"><path d="M19.5 5.5v13h-2v-13zM21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
-{% set _ico_cell3 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="ai-file-actions-icon" aria-hidden="true"><path d="M21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
-
-{#
-  Renders a .page-header-row row from a page_badges dict.
-  Pass an optional variant string to scope the block with data-variant.
-#}
-{% macro render_badges(badges, variant=None) %}
-<div class="page-header-row"{% if variant %} data-variant="{{ variant | e }}"{% endif %}>
-  {%- if badges -%}
-    {%- if badges.test_workflow -%}
-      {%- set _wf = badges.test_workflow | e -%}
-      {%- set _gh = 'https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/' -%}
-      <a class="page-header-item page-header-test-badge" href="{{ _gh }}{{ _wf }}.yml" target="_blank" rel="noopener">
-        <img src="{{ _gh }}{{ _wf }}.yml/badge.svg?event=push" alt="Test status">
-      </a>
-    {%- endif -%}
-    {%- if badges.tutorial_badge -%}
-      {%- set _level = badges.tutorial_badge | lower -%}
-      <span class="page-header-item">
-        {%- if _level == 'beginner' -%}{{ _ico_cell1 }}
-        {%- elif _level == 'intermediate' -%}{{ _ico_cell2 }}
-        {%- elif _level == 'advanced' -%}{{ _ico_cell3 }}
-        {%- endif -%}
-        {{ badges.tutorial_badge }}
-      </span>
-    {%- endif -%}
-  {%- endif -%}
-</div>
-{% endmacro %}
+{% from "partials/page-badges.html" import render_badges %}
 
 {# ------------------------------------------------------------------ #}
 {# Content rendering                                                    #}

--- a/material-overrides/partials/content.html
+++ b/material-overrides/partials/content.html
@@ -62,6 +62,21 @@
     {%- endfor -%}
   {% endset %}
   {% set rendered_content = page.content | replace('<!-- toggle-badges -->', badge_blocks, 1) %}
+  {# Replace per-variant test placeholders injected by the plugin before "Where to Go Next".
+     A namespace is required because Jinja2 for-loop scope does not propagate variable
+     assignments back to the enclosing scope. #}
+  {% if page.meta.toggle_variant_test_metas %}
+    {% set _ns = namespace(content=rendered_content) %}
+    {% for variant, tests, wf in page.meta.toggle_variant_test_metas %}
+      {%- if tests and tests.path -%}
+        {%- set _test_block = render_test_block(wf, tests.path, '') -%}
+      {%- else -%}
+        {%- set _test_block = '' -%}
+      {%- endif -%}
+      {%- set _ns.content = _ns.content | replace('<!-- toggle-tests-' ~ variant ~ ' -->', _test_block, 1) -%}
+    {% endfor %}
+    {% set rendered_content = _ns.content %}
+  {% endif %}
 {% elif "\x3ch1" in page.content %}
   {% set rendered_content = page.content | replace('</h1>', '</h1>' ~ render_badges(page.meta.page_badges), 1) %}
 {% else %}
@@ -73,7 +88,7 @@
 {# Driven by page_tests.path in frontmatter; uses page_badges         #}
 {# .test_workflow (if set) for the CI badge image.                    #}
 {# ------------------------------------------------------------------ #}
-{% if page.meta.page_tests and page.meta.page_tests.path %}
+{% if page.meta.page_tests and page.meta.page_tests.path and not page.meta.toggle_variant_metas %}
   {%- set _wf = page.meta.page_badges.test_workflow if page.meta.page_badges and page.meta.page_badges.test_workflow else None -%}
   {%- set _test_block = render_test_block(_wf, page.meta.page_tests.path, page.title) -%}
   {%- set _wtgn_marker = '<h2 id="where-to-go-next"' -%}

--- a/material-overrides/partials/content.html
+++ b/material-overrides/partials/content.html
@@ -45,34 +45,66 @@
 
 {% if "material/tags" in config.plugins and tags %}
   {% include "partials/tags.html" %}
-{% endif %}  
-
-{% set badge_html = '' %}
-{% if page.meta and page.meta.tutorial_badge %}
-  {% set badge_html = '<span class="badge ' ~ (page.meta.tutorial_badge | lower | replace(".", "-")) ~ '">' ~ (page.meta.tutorial_badge | capitalize) ~ '</span>' %}
 {% endif %}
 
+{# ------------------------------------------------------------------ #}
+{# Page details row — rendered directly below the H1                  #}
+{# Contains: tutorial badge, test status badge, ai dropdowns.         #}
+{# ------------------------------------------------------------------ #}
+
+{# Signal-cellular icons for difficulty level #}
+{% set _ico_cell1 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="ai-file-actions-icon" aria-hidden="true"><path d="M19.5 5.5v13h-2v-13zm-7 5v8h-2v-8zM21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
+{% set _ico_cell2 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="ai-file-actions-icon" aria-hidden="true"><path d="M19.5 5.5v13h-2v-13zM21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
+{% set _ico_cell3 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="ai-file-actions-icon" aria-hidden="true"><path d="M21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
+
+{# --- Assemble the full page-details row --- #}
+{% set page_details_html %}
+<div class="page-details">
+  {%- if page.meta and page.meta.test_workflow -%}
+    {%- set _wf = page.meta.test_workflow | e -%}
+    {%- set _gh = 'https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/' -%}
+    <a class="page-detail-item page-detail-test-badge" href="{{ _gh }}{{ _wf }}.yml" target="_blank" rel="noopener">
+      <img src="{{ _gh }}{{ _wf }}.yml/badge.svg?event=push" alt="Test status">
+    </a>
+  {%- endif -%}
+  {%- if page.meta and page.meta.tutorial_badge -%}
+    {%- set _level = page.meta.tutorial_badge | lower -%}
+    <span class="page-detail-item">
+      {%- if _level == 'beginner' -%}{{ _ico_cell1 }}
+      {%- elif _level == 'intermediate' -%}{{ _ico_cell2 }}
+      {%- elif _level == 'advanced' -%}{{ _ico_cell3 }}
+      {%- endif -%}
+      {{ page.meta.tutorial_badge }}
+    </span>
+  {%- endif -%}
+</div>
+{% endset %}
+
+{# ------------------------------------------------------------------ #}
+{# Content rendering                                                    #}
+{# ------------------------------------------------------------------ #}
+
 {% if "\x3ch1" in page.content %}
-  {% set rendered_content = page.content | replace('</h1>', '</h1>' ~ badge_html, 1) %}
+  {% set rendered_content = page.content | replace('</h1>', '</h1>' ~ page_details_html, 1) %}
 {% else %}
-  {% set rendered_content = '<h1>' ~ (page.title | d(config.site_name, true)) ~ '</h1>' ~ badge_html ~ page.content %}
+  {% set rendered_content = '<h1>' ~ (page.title | d(config.site_name, true)) ~ '</h1>' ~ page_details_html ~ page.content %}
 {% endif %}
 
 {% if "faq" in page.url %}
   {# Split content for each FAQ by h2 #}
   {% set h2_sections = rendered_content.split('<h2') %}
   {% set intro_content = h2_sections[0] %}
-  
+
   {# Keep any introduction content intact #}
   {% if intro_content %}
     {{ intro_content | safe }}
   {% endif %}
-  
+
   {# Process each FAQ section #}
   {% for i in range(1, h2_sections | length) %}
     {% set section = h2_sections[i] %}
     {% set section_counter = loop.index %}
-    
+
     {# Extract h2 content #}
     {% set h2_end = section.find('</h2>') %}
     {% if h2_end != -1 %}
@@ -83,7 +115,7 @@
       {% set normalized_h2_text = h2_text | striptags | trim %}
       {% set h2_attributes_lower = h2_attributes | lower %}
       {% set is_excluded_h2 = normalized_h2_text == "Where to Go Next" or 'id="where-to-go-next"' in h2_attributes_lower %}
-      
+
       {# Extract ID from h2 attributes #}
       {% set id_start = h2_attributes.find('id="') %}
       {% set h2_id = '' %}
@@ -92,11 +124,11 @@
         {% set id_end = h2_attributes.find('"', id_start) %}
         {% set h2_id = h2_attributes[id_start:id_end] %}
       {% endif %}
-      
+
       {# Get content after h2 until next h2 or end of page #}
       {% set h2_closing_tag_length = 5 %} {# Length of '</h2>' #}
       {% set section_content = section[h2_end + h2_closing_tag_length:] %}
-      
+
       {% if is_excluded_h2 %}
         <h2{{ h2_attributes | safe }}>{{ h2_text | safe }}</h2>
         {{ section_content | safe }}

--- a/material-overrides/partials/page-badges.html
+++ b/material-overrides/partials/page-badges.html
@@ -13,9 +13,9 @@
 -#}
 
 {# Signal-cellular icons for tutorial difficulty level #}
-{% set _ico_cell1 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="ai-file-actions-icon" aria-hidden="true"><path d="M19.5 5.5v13h-2v-13zm-7 5v8h-2v-8zM21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
-{% set _ico_cell2 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="ai-file-actions-icon" aria-hidden="true"><path d="M19.5 5.5v13h-2v-13zM21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
-{% set _ico_cell3 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="ai-file-actions-icon" aria-hidden="true"><path d="M21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
+{% set _ico_cell1 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="page-header-item-icon" aria-hidden="true"><path d="M19.5 5.5v13h-2v-13zm-7 5v8h-2v-8zM21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
+{% set _ico_cell2 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="page-header-item-icon" aria-hidden="true"><path d="M19.5 5.5v13h-2v-13zM21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
+{% set _ico_cell3 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="page-header-item-icon" aria-hidden="true"><path d="M21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
 
 {% macro render_badges(badges, variant=None) %}
 <div class="page-header-row"{% if variant %} data-variant="{{ variant | e }}"{% endif %}>

--- a/material-overrides/partials/page-badges.html
+++ b/material-overrides/partials/page-badges.html
@@ -1,0 +1,41 @@
+{#-
+  Exports the render_badges macro for use in content.html.
+
+  render_badges(badges, variant=None)
+    Renders a single .page-header-row div containing tutorial difficulty and
+    CI test-workflow badges sourced from page frontmatter.
+
+      badges  — a page_badges dict from frontmatter (may be None/empty)
+      variant — optional data-variant string; when set, scopes the row with
+                data-variant so the ai_docs plugin can inject the per-page AI
+                widget into the correct slot on toggle pages.
+-#}
+
+{# Signal-cellular icons for tutorial difficulty level #}
+{% set _ico_cell1 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="ai-file-actions-icon" aria-hidden="true"><path d="M19.5 5.5v13h-2v-13zm-7 5v8h-2v-8zM21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
+{% set _ico_cell2 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="ai-file-actions-icon" aria-hidden="true"><path d="M19.5 5.5v13h-2v-13zM21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
+{% set _ico_cell3 %}<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="ai-file-actions-icon" aria-hidden="true"><path d="M21 4h-5v16h5zm-7 5H9v11h5zm-7 5H2v6h5z"/></svg>{% endset %}
+
+{% macro render_badges(badges, variant=None) %}
+<div class="page-header-row"{% if variant %} data-variant="{{ variant | e }}"{% endif %}>
+  {%- if badges -%}
+    {%- if badges.test_workflow -%}
+      {%- set _wf = badges.test_workflow | e -%}
+      {%- set _gh = 'https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/' -%}
+      <a class="page-header-item page-header-test-badge" href="{{ _gh }}{{ _wf }}.yml" target="_blank" rel="noopener">
+        <img src="{{ _gh }}{{ _wf }}.yml/badge.svg?event=push" alt="Test status">
+      </a>
+    {%- endif -%}
+    {%- if badges.tutorial_badge -%}
+      {%- set _level = badges.tutorial_badge | lower -%}
+      <span class="page-header-item">
+        {%- if _level == 'beginner' -%}{{ _ico_cell1 }}
+        {%- elif _level == 'intermediate' -%}{{ _ico_cell2 }}
+        {%- elif _level == 'advanced' -%}{{ _ico_cell3 }}
+        {%- endif -%}
+        {{ badges.tutorial_badge }}
+      </span>
+    {%- endif -%}
+  {%- endif -%}
+</div>
+{% endmacro %}

--- a/material-overrides/partials/page-badges.html
+++ b/material-overrides/partials/page-badges.html
@@ -3,7 +3,8 @@
 
   render_badges(badges, variant=None)
     Renders a single .page-header-row div containing tutorial difficulty and
-    CI test-workflow badges sourced from page frontmatter.
+    CI test-workflow badges sourced from page frontmatter. AI dropdowns are also
+    injected into this div by the ai_docs plugin.
 
       badges  — a page_badges dict from frontmatter (may be None/empty)
       variant — optional data-variant string; when set, scopes the row with

--- a/material-overrides/partials/page-tests.html
+++ b/material-overrides/partials/page-tests.html
@@ -22,7 +22,7 @@
   </a>
   {%- endif -%}
   <a href="{{ _gh }}/blob/master/{{ test_path | e }}" class="tests-button" target="_blank" rel="noopener">
-    {% include ".icons/material/code-tags.svg" %} View tests
+    <span class="twemoji">{% include ".icons/material/code-tags.svg" %}</span> View tests
   </a>
 </div>
 {% endmacro %}

--- a/material-overrides/partials/page-tests.html
+++ b/material-overrides/partials/page-tests.html
@@ -1,0 +1,28 @@
+{#-
+  Exports the render_test_block macro for use in content.html.
+
+  render_test_block(workflow, test_path, page_title='')
+    Renders a .status-badge div containing a CI workflow badge and a
+    "View tests" link, injected at the bottom of a page (before the
+    "Where to Go Next" section if present, otherwise at the very end).
+
+      workflow   — GitHub Actions workflow name (from page_badges.test_workflow),
+                   or None/falsy to omit the CI badge image
+      test_path  — path to the test file relative to the cookbook repo root
+                   (sourced from page_tests.path in page frontmatter)
+      page_title — used as alt text on the CI badge image
+-#}
+
+{% macro render_test_block(workflow, test_path, page_title='') %}
+{%- set _gh = 'https://github.com/polkadot-developers/polkadot-cookbook' -%}
+<div class="status-badge">
+  {%- if workflow -%}
+  <a href="{{ _gh }}/actions/workflows/{{ workflow | e }}.yml" target="_blank" rel="noopener">
+    <img src="{{ _gh }}/actions/workflows/{{ workflow | e }}.yml/badge.svg?event=push" alt="{{ page_title | e }}">
+  </a>
+  {%- endif -%}
+  <a href="{{ _gh }}/blob/master/{{ test_path | e }}" class="tests-button" target="_blank" rel="noopener">
+    {% include ".icons/material/code-tags.svg" %} View tests
+  </a>
+</div>
+{% endmacro %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,6 +120,9 @@ plugins:
   - ai_docs:
       llms_config: llms_config.json
       enabled: !ENV [ENABLED_LLMS_PLUGINS, True]
+      ai_page_actions_anchor: page-details
+      ai_page_actions_style: dropdown
+      ai_page_actions_dropdown_label: 'Markdown for LLMs'
   - awesome-nav
   - git-revision-date-localized:
       type: date

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,15 +117,21 @@ hooks:
 # Plugins
 plugins:
   - search
-  - exclude-search:
-      exclude:
-        - ai/*
-  - awesome-nav
   - ai_docs:
       llms_config: llms_config.json
       enabled: !ENV [ENABLED_LLMS_PLUGINS, True]
-  - page_toggle
+  - awesome-nav
+  - git-revision-date-localized:
+      type: date
+      enable_creation_date: true
+      exclude:
+        - node_modules/*
+      enabled: !ENV [ENABLED_GIT_REVISION_DATE, True]
   - glightbox
+  - link_processor
+  - macros:
+      include_yaml:
+        - polkadot-docs/variables.yml
   - minify:
       minify_html: true
       minify_js: true
@@ -150,15 +156,7 @@ plugins:
           - assets/stylesheets/home.css
         main.html:
           - assets/stylesheets/polkadot.css   
-  - macros:
-      include_yaml:
-        - polkadot-docs/variables.yml
-  - git-revision-date-localized:
-      type: date
-      enable_creation_date: true
-      exclude:
-        - node_modules/*
-      enabled: !ENV [ENABLED_GIT_REVISION_DATE, True]
+  - page_toggle
   - social:
       enabled: !ENV [SOCIAL_CARDS, True]
       cards_layout_dir: layouts

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,7 +120,7 @@ plugins:
   - ai_docs:
       llms_config: llms_config.json
       enabled: !ENV [ENABLED_LLMS_PLUGINS, True]
-      ai_page_actions_anchor: page-details
+      ai_page_actions_anchor: page-header-row
       ai_page_actions_style: dropdown
       ai_page_actions_dropdown_label: 'Markdown for LLMs'
   - awesome-nav


### PR DESCRIPTION
This pull request introduces a comprehensive redesign and refactoring of the page header badges and AI file actions UI in the documentation site. The main goals are to modularize badge rendering, improve styling consistency, and better support new features like per-variant badges and AI dropdowns. The changes touch Jinja templates, CSS, and MkDocs plugin configuration.

**Key changes include:**

### Badge and Test Block Rendering

- Introduced two new Jinja partials: `page-badges.html` and `page-tests.html`, each exporting macros to render page header badges (tutorial difficulty, CI status) and test blocks, respectively. This modularizes badge logic and enables flexible placement and per-variant support. [[1]](diffhunk://#diff-0211efe38ffe372133025bafd7268507f24b2b6398e7917b055464f79c7a88c4R1-R42) [[2]](diffhunk://#diff-d45fa3bd71578f3bbbe5ccb633fc6c782c1cd8485a38497136ca5fd2794125d8R1-R28)
- Refactored `content.html` to use these macros, supporting toggle pages with variant-specific badges and injecting test blocks before the "Where to Go Next" section or at the end of the page.

### CSS and UI Improvements

- Added and updated styles in `polkadot.css` and `ai-file-actions.css` for the new `.page-header-row` and `.page-header-item` classes, ensuring consistent appearance and layout for badges, test buttons, and AI dropdowns. [[1]](diffhunk://#diff-a6c8eae84cfc8cfaab7caca9007bb674535981c57b9aaabc22aaa3e08fc62934R1151-R1194) [[2]](diffhunk://#diff-2449ad92e3950c33ec3d5094a24696381de84ef35cffcedf9155f5cfe2fa3082R221-R254)
- Improved accessibility and visual consistency for badge images and dropdown items, including support for both anchor and button elements in AI file actions. [[1]](diffhunk://#diff-2449ad92e3950c33ec3d5094a24696381de84ef35cffcedf9155f5cfe2fa3082L130-R132) [[2]](diffhunk://#diff-2449ad92e3950c33ec3d5094a24696381de84ef35cffcedf9155f5cfe2fa3082L151-R154) [[3]](diffhunk://#diff-a6c8eae84cfc8cfaab7caca9007bb674535981c57b9aaabc22aaa3e08fc62934L1142-L1145)

### AI Plugin Integration

- Updated the `ai_docs` plugin configuration in `mkdocs.yml` to anchor AI page actions to the new `.page-header-row` and use the dropdown style, aligning plugin behavior with the new UI structure.

### Code and Style Cleanup

- Removed obsolete badge rendering logic and redundant CSS, consolidating badge styling and ensuring that all badge-related elements use the new structure. [[1]](diffhunk://#diff-a6c8eae84cfc8cfaab7caca9007bb674535981c57b9aaabc22aaa3e08fc62934L1133) [[2]](diffhunk://#diff-a6c8eae84cfc8cfaab7caca9007bb674535981c57b9aaabc22aaa3e08fc62934L671-L675) [[3]](diffhunk://#diff-b136535c130023be54087cef55711848fb091900ac82a61ca73a176d168e1e78L10-R27)

These changes collectively provide a more maintainable, extensible, and visually consistent system for displaying badges, test status, and AI actions in the documentation site.

---

### Goes with https://github.com/polkadot-developers/polkadot-docs/pull/1609