### PR TITLE
fix: update banner

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -35,7 +35,7 @@
 {%- endblock -%}
 
 {% block announce %}
-  <strong>Web3 Summit 2026</strong> | A Festival for Digital Freedom | Funkhaus Berlin 18,19 June | <a href="https://web3summit.com/" target="_blank">https://web3summit.com/</a>
+  <strong>Web3 Summit 2026</strong> | A Festival for Digital Freedom | Funkhaus Berlin June 18-19th | <a href="https://web3summit.com/" target="_blank">https://web3summit.com/</a>
 {% endblock %}
 
 {% block libs %}

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -35,7 +35,7 @@
 {%- endblock -%}
 
 {% block announce %}
-  <strong>Connect to Polkadot docs via MCP</strong>. Query the documentation directly from Claude, Cursor, or any MCP-compatible AI client. 👉 <a href="{{ 'ai-resources/' | url }}#connect-via-mcp">Get started</a>.
+  <strong>Web3 Summit 2026</strong> | A Festival for Digital Freedom | Funkhaus Berlin 18,19 June | <a href="https://web3summit.com/" target="_blank">https://web3summit.com/</a>
 {% endblock %}
 
 {% block libs %}


### PR DESCRIPTION
This pull request updates the announcement banner in the `material-overrides/main.html` file. The previous message about connecting to Polkadot docs via MCP has been replaced with information about the Web3 Summit 2026 event.

- Announcement banner now promotes the Web3 Summit 2026, including event details and a link to the summit website, replacing the previous MCP documentation message.

Leaving this PR in draft until this Thursday