### PR TITLE
add Makefile and Makefile.bat with install, serve, build, and gen-coo…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+VENV        := venv
+PIP         := $(VENV)/bin/pip
+MKDOCS      := $(VENV)/bin/mkdocs
+PYTHON      := $(VENV)/bin/python
+SCRIPTS_DIR := scripts
+
+PYTHON_BIN := $(shell command -v python3 2>/dev/null || command -v python 2>/dev/null)
+
+ifeq ($(PYTHON_BIN),)
+$(error No Python interpreter found. Install Python 3 from https://python.org and ensure it is on your PATH)
+endif
+
+.DEFAULT_GOAL := help
+
+$(VENV)/.installed: requirements.txt
+	@echo "Using $(PYTHON_BIN) to create virtual environment..."
+	$(PYTHON_BIN) -m venv $(VENV) || \
+		(echo "\nError: Failed to create virtual environment.\n  On Debian/Ubuntu: sudo apt install python3-venv\n  On macOS: reinstall Python from https://python.org" && exit 1)
+	$(PIP) install --upgrade pip setuptools 'cython<3.0.0' wheel || \
+		(echo "\nError: Failed to upgrade pip. Check your internet connection and try again." && exit 1)
+	$(PIP) install -r requirements.txt || \
+		(echo "\nError: Failed to install dependencies from requirements.txt.\n  Verify the file exists and your internet connection is working, then re-run: make install" && exit 1)
+	@touch $@
+	@echo "Setup complete."
+
+.PHONY: install
+install: $(VENV)/.installed ## Install Python dependencies into the venv
+
+.PHONY: serve
+serve: $(VENV)/.installed ## Serve docs locally with live reload (http://127.0.0.1:8000)
+	$(MKDOCS) serve || \
+		(echo "\nError: Failed to start the local server.\n  If port 8000 is already in use, run: $(MKDOCS) serve --dev-addr=127.0.0.1:8001" && exit 1)
+
+.PHONY: build
+build: $(VENV)/.installed ## Build the static site and validate it compiles cleanly
+	$(MKDOCS) build --strict || \
+		(echo "\nError: Build failed. Fix the errors above, then re-run: make build\n  Tip: run 'make serve' to preview and identify broken references interactively." && exit 1)
+
+.PHONY: gen-cookbook
+gen-cookbook: $(VENV)/.installed ## Generate the cookbook index table (pass TARGET=path/to/section)
+ifndef TARGET
+	$(error TARGET is required. Example: make gen-cookbook TARGET=smart-contracts/cookbook)
+endif
+	$(PYTHON) $(SCRIPTS_DIR)/generate-cookbook-indexes.py $(TARGET) || \
+		(echo "\nError: Failed to generate cookbook index for '$(TARGET)'.\n  Ensure the path exists under polkadot-docs/ and contains a .nav.yml file." && exit 1)
+
+.PHONY: help
+help:
+	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  install       to create a virtual environment and install all doc dependencies"
+	@echo "  serve         to watch, rebuild, and serve the docs locally with live reload (http://127.0.0.1:8000)"
+	@echo "  build         to build the static site and validate it compiles cleanly (mirrors CI)"
+	@echo "  gen-cookbook  to regenerate the cookbook index table (requires TARGET=path/to/section)"

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,12 @@ MKDOCS      := $(VENV)/bin/mkdocs
 PYTHON      := $(VENV)/bin/python
 SCRIPTS_DIR := scripts
 
-PYTHON_BIN := $(shell command -v python3 2>/dev/null || command -v python 2>/dev/null)
+PYTHON_BIN := $(shell command -v python3.10 2>/dev/null || command -v python3 2>/dev/null || command -v python 2>/dev/null)
+
+ARGS ?=
 
 ifeq ($(PYTHON_BIN),)
-$(error No Python interpreter found. Install Python 3 from https://python.org and ensure it is on your PATH)
+$(error No Python interpreter found. Install Python 3.10 from https://python.org and ensure it is on your PATH)
 endif
 
 .DEFAULT_GOAL := help
@@ -16,7 +18,7 @@ $(VENV)/.installed: requirements.txt
 	@echo "Using $(PYTHON_BIN) to create virtual environment..."
 	$(PYTHON_BIN) -m venv $(VENV) || \
 		(echo "\nError: Failed to create virtual environment.\n  On Debian/Ubuntu: sudo apt install python3-venv\n  On macOS: reinstall Python from https://python.org" && exit 1)
-	$(PIP) install --upgrade pip setuptools 'cython<3.0.0' wheel || \
+	$(PIP) install --upgrade pip || \
 		(echo "\nError: Failed to upgrade pip. Check your internet connection and try again." && exit 1)
 	$(PIP) install -r requirements.txt || \
 		(echo "\nError: Failed to install dependencies from requirements.txt.\n  Verify the file exists and your internet connection is working, then re-run: make install" && exit 1)
@@ -26,14 +28,19 @@ $(VENV)/.installed: requirements.txt
 .PHONY: install
 install: $(VENV)/.installed ## Install Python dependencies into the venv
 
+.PHONY: reinstall
+reinstall: ## Force reinstall of all dependencies
+	rm -f $(VENV)/.installed
+	@$(MAKE) --no-print-directory install
+
 .PHONY: serve
 serve: $(VENV)/.installed ## Serve docs locally with live reload (http://127.0.0.1:8000)
-	$(MKDOCS) serve || \
+	$(MKDOCS) serve $(ARGS) || \
 		(echo "\nError: Failed to start the local server.\n  If port 8000 is already in use, run: $(MKDOCS) serve --dev-addr=127.0.0.1:8001" && exit 1)
 
 .PHONY: build
 build: $(VENV)/.installed ## Build the static site and validate it compiles cleanly
-	$(MKDOCS) build --strict || \
+	$(MKDOCS) build --strict $(ARGS) || \
 		(echo "\nError: Build failed. Fix the errors above, then re-run: make build\n  Tip: run 'make serve' to preview and identify broken references interactively." && exit 1)
 
 .PHONY: gen-cookbook
@@ -48,6 +55,9 @@ endif
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  install       to create a virtual environment and install all doc dependencies"
+	@echo "  reinstall     to force reinstall of all dependencies (use when remote requirements change)"
 	@echo "  serve         to watch, rebuild, and serve the docs locally with live reload (http://127.0.0.1:8000)"
+	@echo "                  pass extra flags with ARGS: make serve ARGS='--watch-theme'"
 	@echo "  build         to build the static site and validate it compiles cleanly (mirrors CI)"
+	@echo "                  pass extra flags with ARGS: make build ARGS='-d site'"
 	@echo "  gen-cookbook  to regenerate the cookbook index table (requires TARGET=path/to/section)"

--- a/Makefile.bat
+++ b/Makefile.bat
@@ -1,0 +1,107 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set VENV=venv
+set PIP=%VENV%\Scripts\pip.exe
+set MKDOCS=%VENV%\Scripts\mkdocs.exe
+set PYTHON=%VENV%\Scripts\python.exe
+set SCRIPTS_DIR=scripts
+
+:: Detect python3 or python
+set PYTHON_BIN=
+where python3 >nul 2>&1 && set PYTHON_BIN=python3
+if "%PYTHON_BIN%"=="" where python >nul 2>&1 && set PYTHON_BIN=python
+if "%PYTHON_BIN%"=="" (
+    echo Error: No Python interpreter found.
+    echo Install Python 3 from https://python.org and ensure it is added to PATH.
+    exit /b 1
+)
+
+if "%1"=="" goto help
+if "%1"=="install" goto install
+if "%1"=="serve" goto serve
+if "%1"=="build" goto build
+if "%1"=="gen-cookbook" goto gen-cookbook
+if "%1"=="help" goto help
+echo Unknown target: %1
+goto help
+
+:install
+if exist %VENV%\.installed goto :eof
+echo Using %PYTHON_BIN% to create virtual environment...
+%PYTHON_BIN% -m venv %VENV%
+if errorlevel 1 (
+    echo.
+    echo Error: Failed to create virtual environment.
+    echo   Ensure Python 3 is installed and the venv module is available.
+    echo   On Windows, reinstall Python from https://python.org and check "Add to PATH".
+    exit /b 1
+)
+%PIP% install --upgrade pip setuptools "cython<3.0.0" wheel
+if errorlevel 1 (
+    echo.
+    echo Error: Failed to upgrade pip.
+    echo   Check your internet connection and try again.
+    exit /b 1
+)
+%PIP% install -r requirements.txt
+if errorlevel 1 (
+    echo.
+    echo Error: Failed to install dependencies from requirements.txt.
+    echo   Verify the file exists and your internet connection is working.
+    echo   Then re-run: Makefile.bat install
+    exit /b 1
+)
+type nul > %VENV%\.installed
+echo Setup complete.
+goto :eof
+
+:serve
+if not exist %VENV%\.installed call :install
+if errorlevel 1 exit /b 1
+%MKDOCS% serve
+if errorlevel 1 (
+    echo.
+    echo Error: Failed to start the local server.
+    echo   If port 8000 is already in use, run manually:
+    echo   %MKDOCS% serve --dev-addr=127.0.0.1:8001
+    exit /b 1
+)
+goto :eof
+
+:build
+if not exist %VENV%\.installed call :install
+if errorlevel 1 exit /b 1
+%MKDOCS% build --strict
+if errorlevel 1 (
+    echo.
+    echo Error: Build failed. Fix the errors above, then re-run: Makefile.bat build
+    echo   Tip: run "Makefile.bat serve" to preview and identify broken references interactively.
+    exit /b 1
+)
+goto :eof
+
+:gen-cookbook
+if "%TARGET%"=="" (
+    echo Error: TARGET is required.
+    echo   Usage: set TARGET=smart-contracts/cookbook ^& Makefile.bat gen-cookbook
+    exit /b 1
+)
+if not exist %VENV%\.installed call :install
+if errorlevel 1 exit /b 1
+%PYTHON% %SCRIPTS_DIR%\generate-cookbook-indexes.py %TARGET%
+if errorlevel 1 (
+    echo.
+    echo Error: Failed to generate cookbook index for "%TARGET%".
+    echo   Ensure the path exists under polkadot-docs/ and contains a .nav.yml file.
+    exit /b 1
+)
+goto :eof
+
+:help
+echo Please use "Makefile.bat [target]" where [target] is one of:
+echo   install       to create a virtual environment and install all doc dependencies
+echo   serve         to watch, rebuild, and serve the docs locally with live reload (http://127.0.0.1:8000)
+echo   build         to build the static site and validate it compiles cleanly (mirrors CI)
+echo   gen-cookbook  to regenerate the cookbook index table (set TARGET=path/to/section)
+goto :eof

--- a/Makefile.bat
+++ b/Makefile.bat
@@ -9,7 +9,8 @@ set SCRIPTS_DIR=scripts
 
 :: Detect python3 or python
 set PYTHON_BIN=
-where python3 >nul 2>&1 && set PYTHON_BIN=python3
+where python3.10 >nul 2>&1 && set PYTHON_BIN=python3.10
+if "%PYTHON_BIN%"=="" where python3 >nul 2>&1 && set PYTHON_BIN=python3
 if "%PYTHON_BIN%"=="" where python >nul 2>&1 && set PYTHON_BIN=python
 if "%PYTHON_BIN%"=="" (
     echo Error: No Python interpreter found.
@@ -19,12 +20,17 @@ if "%PYTHON_BIN%"=="" (
 
 if "%1"=="" goto help
 if "%1"=="install" goto install
+if "%1"=="reinstall" goto reinstall
 if "%1"=="serve" goto serve
 if "%1"=="build" goto build
 if "%1"=="gen-cookbook" goto gen-cookbook
 if "%1"=="help" goto help
 echo Unknown target: %1
 goto help
+
+:reinstall
+if exist %VENV%\.installed del %VENV%\.installed
+goto install
 
 :install
 if exist %VENV%\.installed goto :eof
@@ -37,7 +43,7 @@ if errorlevel 1 (
     echo   On Windows, reinstall Python from https://python.org and check "Add to PATH".
     exit /b 1
 )
-%PIP% install --upgrade pip setuptools "cython<3.0.0" wheel
+%PIP% install --upgrade pip
 if errorlevel 1 (
     echo.
     echo Error: Failed to upgrade pip.
@@ -59,7 +65,7 @@ goto :eof
 :serve
 if not exist %VENV%\.installed call :install
 if errorlevel 1 exit /b 1
-%MKDOCS% serve
+%MKDOCS% serve %~2
 if errorlevel 1 (
     echo.
     echo Error: Failed to start the local server.
@@ -72,7 +78,7 @@ goto :eof
 :build
 if not exist %VENV%\.installed call :install
 if errorlevel 1 exit /b 1
-%MKDOCS% build --strict
+%MKDOCS% build --strict %~2
 if errorlevel 1 (
     echo.
     echo Error: Build failed. Fix the errors above, then re-run: Makefile.bat build
@@ -101,7 +107,10 @@ goto :eof
 :help
 echo Please use "Makefile.bat [target]" where [target] is one of:
 echo   install       to create a virtual environment and install all doc dependencies
+echo   reinstall     to force reinstall of all dependencies (use when remote requirements change)
 echo   serve         to watch, rebuild, and serve the docs locally with live reload (http://127.0.0.1:8000)
+echo                   pass extra flags as a second arg: Makefile.bat serve "--watch-theme"
 echo   build         to build the static site and validate it compiles cleanly (mirrors CI)
+echo                   pass extra flags as a second arg: Makefile.bat build "-d site"
 echo   gen-cookbook  to regenerate the cookbook index table (set TARGET=path/to/section)
 goto :eof

--- a/README.md
+++ b/README.md
@@ -20,14 +20,6 @@ git clone https://github.com/papermoonio/polkadot-mkdocs
 cd polkadot-mkdocs
 ```
 
-### Install Dependencies
-
-To get started you need to have [Mkdocs](https://www.mkdocs.org/) installed. All dependencies can be installed with a single command, you can run:
-
-```bash
-pip install -r requirements.txt
-```
-
 ## Set Up Repository Structure
 
 In order for everything to work correctly, the structure needs to be as follows:
@@ -60,6 +52,18 @@ Makefile.bat serve
 ```
 
 This will install dependencies automatically if you haven't already, then start the local server. After a successful build, the site is available at `http://127.0.0.1:8000` with live reload on file changes.
+
+To pass extra flags to `mkdocs serve`, use the `ARGS` variable:
+
+```bash
+make serve ARGS="--watch-theme"
+```
+
+On Windows, pass them as a second argument:
+
+```bat
+Makefile.bat serve "--watch-theme"
+```
 
 > **_NOTE:_** To improve build times, you can:
 

--- a/README.md
+++ b/README.md
@@ -47,15 +47,35 @@ git clone https://github.com/polkadot-developers/polkadot-docs.git
 
 ## Run the Docs
 
-Now in the `polkadot-mkdocs` folder, you can build the site by running:
+From the `polkadot-mkdocs` folder, run:
 
 ```bash
-mkdocs serve
+make serve
 ```
+
+On Windows:
+
+```bat
+Makefile.bat serve
+```
+
+This will install dependencies automatically if you haven't already, then start the local server. After a successful build, the site is available at `http://127.0.0.1:8000` with live reload on file changes.
 
 > **_NOTE:_** To improve build times, you can:
 
 > - Disable the git revision plugin by running the following command before you serve the docs: `export ENABLED_GIT_REVISION_DATE=false`
 > - Disable the LLM file plugins for local development by running the following command before you serve the docs: `export ENABLED_LLMS_PLUGINS=false`
 
-After a successful build, the site should be available locally at `http://127.0.0.1:8000`.
+## Optional Quality Checks
+
+To validate the site builds cleanly with strict mode (the same check that runs in CI):
+
+```bash
+make build
+```
+
+On Windows:
+
+```bat
+Makefile.bat build
+```


### PR DESCRIPTION
While setting up the docs locally, there were a lot of steps that could be compressed using makefiles. So I wrote these makefiles to make the workflow simpler.

## Summary

Adds a `Makefile` (macOS/Linux) and `Makefile.bat` (Windows) to `polkadot-mkdocs`
to standardise common local development tasks.

Both files:
- Auto-detect `python3` or `python` and error with install instructions if neither is found
- Create and manage a virtual environment automatically
- Guard every command with descriptive error messages that tell the user exactly what failed and how to fix it

### Available targets

| Target | Description |
|---|---|
| `install` | Create a virtual environment and install all doc dependencies |
| `serve` | Watch, rebuild, and serve the docs locally with live reload |
| `build` | Build the static site in strict mode (mirrors CI) |
| `gen-cookbook` | Regenerate the cookbook index table for a given section |

READMEs in both `polkadot-mkdocs` and `polkadot-docs` are updated to reflect the new commands.

