### PR TITLE
Header button styling

### DIFF
--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -499,6 +499,14 @@ input.md-search__input::placeholder {
     max-width: 100%;
     opacity: 1;
   }
+
+  [data-md-toggle="search"]:checked ~ .md-header .md-header__tools,
+  [data-md-toggle="search"]:checked
+    ~ .md-header
+    .md-header__option[data-md-component="palette"]
+    .md-header__button {
+    z-index: 0;
+  }
 }
 
 @media screen and (max-width: 59.9844em) {


### PR DESCRIPTION
This pull request makes a targeted adjustment to the search UI in the `polkadot.css` stylesheet. The main change lowers the `z-index` of certain header elements when the search is active, likely to ensure that the search overlay displays correctly above other header tools and palette buttons.

UI layering adjustment:

* Updated CSS to set `z-index: 0` for `.md-header__tools` and palette `.md-header__button` when the search toggle is active, improving the stacking order of header elements during search.

<img width="1425" height="107" alt="image" src="https://github.com/user-attachments/assets/e7482e39-6b8b-4950-bc99-2a86bc74ff9f" />
