### PR TITLE
Add Instant preview plugin

### DIFF
--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1720,15 +1720,14 @@ h1.not-found {
 
 /* --- Tooltip  --- */
 .md-tooltip2 > .md-tooltip2__inner {
-    border: 1px solid var(--color-border-strong);
-    border-radius: var(--rounded-lg);
-    scrollbar-color: var(--color-border-strong) transparent;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-lg);
+  scrollbar-color: var(--color-border-strong) transparent;
 }
 
-.md-tooltip2__inner.md-typeset .button-wrapper:has(> a.md-button.connect-metamask){
-  display:flex;
+.md-tooltip2__inner.md-typeset .button-wrapper:has(> a.md-button.connect-metamask) {
+  display: flex;
   flex-direction: column;
   gap: var(--p-2);
-  margin: 0.75rem  0 1rem;
+  margin: 0.75rem 0 1rem;
 }
-

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1717,3 +1717,18 @@ div.mermaid {
 h1.not-found {
   text-align: center;
 }
+
+/* --- Tooltip  --- */
+.md-tooltip2 > .md-tooltip2__inner {
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--rounded-lg);
+    scrollbar-color: var(--color-border-strong) transparent;
+}
+
+.md-tooltip2__inner.md-typeset .button-wrapper:has(> a.md-button.connect-metamask){
+  display:flex;
+  flex-direction: column;
+  gap: var(--p-2);
+  margin: 0.75rem  0 1rem;
+}
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ extra_javascript:
   - js/connect-to-metamask.js
   - js/error-modal.js
   - js/ai-file-actions.js
+  - js/instant-preview.js
   - js/toggle-pages.js
 # Extra CSS files
 extra_css:
@@ -131,6 +132,7 @@ plugins:
       enabled: !ENV [ENABLED_GIT_REVISION_DATE, True]
   - glightbox
   - link_processor
+  - instant_preview
   - macros:
       include_yaml:
         - polkadot-docs/variables.yml
@@ -147,6 +149,7 @@ plugins:
         - js/connect-to-metamask.js
         - js/error-modal.js
         - js/ai-file-actions.js
+        - js/instant-preview.js
         - js/toggle-pages.js
       css_files:
         - assets/stylesheets/terminal.css


### PR DESCRIPTION
This pull request introduces the new "instant preview" feature to the documentation site, along with related style and configuration updates. The main changes involve adding the necessary JavaScript, plugin configuration, and custom CSS to support and style instant previews and tooltips.

For testing the styling, it's best to use `setTimeout(() => { debugger }, 3000)` in the console and then hover over a link to freeze it 

This PR needs to be merged with the following: https://github.com/papermoonio/mkdocs-plugins/pull/62 and https://github.com/polkadot-developers/polkadot-docs/pull/1680