### PR TITLE
Exclude AGENTS.md from the docs build

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ validation:
 exclude_docs: |
    README.md
    LICENSE.md
+   AGENTS.md
 
 # Theme related settings
 theme:


### PR DESCRIPTION
## Summary

Add `AGENTS.md` to `exclude_docs` so it isn't published as a page.

## Why

[polkadot-developers/polkadot-docs#1678](https://github.com/polkadot-developers/polkadot-docs/pull/1678) introduces an `AGENTS.md` at the root of the docs content repo — instructions for coding agents authoring docs (styleguide adoption), not reader-facing content. Since `docs_dir` is `polkadot-docs`, without this exclusion it would be built and served at `docs.polkadot.com/AGENTS.md`.

This excludes it the same way `README.md` and `LICENSE.md` are already excluded. Flagged by @eshaben in the review of that PR.
