### PR TITLE
Merge apps changes

### DIFF
--- a/llms_config.json
+++ b/llms_config.json
@@ -23,6 +23,11 @@
     "docs_dir": ".",
     "base_context_categories": ["basics", "reference"],
     "categories_info": {
+      "apps": {
+        "id": "apps",
+        "name": "Apps",
+        "description": "Building and shipping Products on the Polkadot platform, from identity setup and local development through to deployment and discovery."
+      },
       "basics": {
         "id": "basics",
         "name": "Basics",

--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -60,7 +60,7 @@
                   {% include ".icons/material/arrow-right.svg" %} 
                 </span>
               </a>
-              <a href="/apps/deploy-and-publish/publish-your-app-bundle/">
+              <a href="/apps/deploy-your-app/">
                 Deploy and publish an app
                 <span class="twemoji">
                   {% include ".icons/material/arrow-right.svg" %} 

--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -41,6 +41,33 @@
         <div class="feature-section">
           <div class="featured-content row">
             <div class="card column">
+              <h3>Apps</h3>
+              <a href="/apps/quick-start/">
+                Create a Product quick start
+                <span class="twemoji">
+                  {% include ".icons/material/arrow-right.svg" %} 
+                </span>
+              </a>
+              <a href="/apps/get-started/">
+                Set up your app dev environment
+                <span class="twemoji">
+                  {% include ".icons/material/arrow-right.svg" %} 
+                </span>
+              </a>
+              <a href="/apps/build/">
+                Build an app locally
+                <span class="twemoji">
+                  {% include ".icons/material/arrow-right.svg" %} 
+                </span>
+              </a>
+              <a href="/apps/deploy-and-publish/publish-your-app-bundle/">
+                Deploy and publish an app
+                <span class="twemoji">
+                  {% include ".icons/material/arrow-right.svg" %} 
+                </span>
+              </a>
+            </div>
+            <div class="card column">
               <h3>Smart Contracts</h3>
               <a href="/smart-contracts/connect/">
                 Connect to Polkadot
@@ -85,21 +112,6 @@
                 Upgrade your chain
                 <span class="twemoji">
                   {% include ".icons/material/arrow-right.svg" %} 
-                </span>
-              </a>
-            </div>
-            <div class="card column">
-              <h3>Developer Resources</h3>
-              <a href="https://polkadot.academy/" target="_blank">
-                Discover the Polkadot Academy
-                <span class="twemoji">
-                  {% include ".icons/material/arrow-top-right.svg" %} 
-                </span>
-              </a>
-              <a href="https://www.parity.io/bug-bounty" target="_blank">
-                Report a bug via the bug bounty program
-                <span class="twemoji">
-                  {% include ".icons/material/arrow-top-right.svg" %} 
                 </span>
               </a>
             </div>

--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -19,17 +19,17 @@
           <h1>Polkadot Documentation</h1>
           <p class="tagline">Everything you need to start building on Polkadot.</p>
           <div class="button-wrapper">
-            <a href="smart-contracts/overview/">
-              <button class="md-button">Start Building
+            <a href="apps/">
+              <button class="md-button">Install the Polkadot App
                 <span class="twemoji">
-                  {% include ".icons/material/arrow-right.svg" %} 
+                  {% include ".icons/material/arrow-right.svg" %}
                 </span>
               </button>
-            </a>     
-            <a href="smart-contracts/connect/">
-              <button class="md-button secondary">Connect to Polkadot
+            </a>
+            <a href="apps/quick-start/">
+              <button class="md-button secondary">Start Building
                 <span class="twemoji">
-                  {% include ".icons/material/arrow-right.svg" %} 
+                  {% include ".icons/material/arrow-right.svg" %}
                 </span>
               </button>
             </a>


### PR DESCRIPTION
This pull request updates the documentation homepage and configuration to introduce a dedicated "Apps" section, making it easier for users to find resources for building and deploying products on the Polkadot platform. It also reorganizes the homepage's feature cards and updates the main call-to-action buttons to improve the user journey for app developers.

Homepage and navigation improvements:

* Added a new "Apps" card to the homepage (`material-overrides/home.html`), featuring quick links for app development tasks such as starting a product, setting up the dev environment, building locally, and deploying apps.
* Updated the main call-to-action buttons: the primary button now links to the "Install the Polkadot App" page, and the secondary button directs users to the "Start Building" quick start for apps.
* Removed the "Developer Resources" card from the homepage to streamline the feature section and focus on core development paths.

Configuration updates:

* Added a new "apps" category to the documentation configuration (`llms_config.json`), including its id, name, and description for improved categorization and discoverability.