### PR TITLE
fix: adding bulletin faucet to gitignore

### DIFF
--- a/.urlignore
+++ b/.urlignore
@@ -16,6 +16,7 @@ https://certbot.eff.org/
 https://www.npmjs.com/
 https://wiki.polkadot.com/
 https://www.ovhcloud.com/
+https://paritytech.github.io/polkadot-bulletin-chain/
 
 # Ignore sites that block scrapers (403s or 400s)
 https://x.com/


### PR DESCRIPTION
This pull request makes a minor update to the `.urlignore` file, adding a new URL to the ignore list.

* Added `https://paritytech.github.io/polkadot-bulletin-chain/` to the `.urlignore` file to ensure this site is ignored during URL checks.