### PR TITLE
Make .disabled-button non-interactive

### DIFF
--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1052,6 +1052,7 @@ details.interface > summary::before {
   background-color: var(--md-default-fg-color);
   color: var(--md-default-bg-color);
   cursor: default;
+  pointer-events: none;
   text-decoration: none;
   text-overflow: ellipsis;
   overflow: hidden;


### PR DESCRIPTION
Add pointer-events: none to .disabled-button so disabled call-to-action buttons (e.g. the "Coming soon" iOS App Store button on the apps landing page) are fully inert and ignore clicks on their empty href.