### PR TITLE
remove skills from the config so the dropdown doesn't appear

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,7 +125,6 @@ plugins:
       enabled: !ENV [ENABLED_LLMS_PLUGINS, True]
       ai_page_actions_anchor: page-header-row
       ai_page_actions_style: dropdown
-      agent_skills_config: polkadot-docs/agent_skills_config.json
   - awesome-nav
   - git-revision-date-localized:
       type: date


### PR DESCRIPTION
This pull request removes the `agent_skills_config` setting from the `plugins` section in `mkdocs.yml`, this ensures the Agent Skills dropdown doesn't appear on the individual pages.

---

Goes with https://github.com/polkadot-developers/polkadot-docs/pull/1710